### PR TITLE
Add Generate() function for ergonomic stream creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ func CheckAllUsersExist(ctx context.Context, concurrency int, ids []int) error {
 ```
 
 In the example above only the second stage (`mockapi.GetUser`) of the pipeline is context-aware.
-FromSlice works well here since the input is small, iteration is fast and context cancellation prevents expensive API calls regardless.
+**FromSlice** works well here since the input is small, iteration is fast and context cancellation prevents expensive API calls regardless.
 The following example demonstrates how to replace **FromSlice** with **Generate** when full context awareness becomes important.
 
 ```go

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ func CheckAllUsersExist(ctx context.Context, concurrency int, ids []int) error {
 
 In the example above only the second stage (`mockapi.GetUser`) of the pipeline is context-aware.
 **FromSlice** works well here since the input is small, iteration is fast and context cancellation prevents expensive API calls regardless.
-The following example demonstrates how to replace **FromSlice** with **Generate** when full context awareness becomes important.
+The following code demonstrates how to replace **FromSlice** with **Generate** when full context awareness becomes important.
 
 ```go
 idsStream := rill.Generate(func(send func(int), sendErr func(error)) {
@@ -316,7 +316,8 @@ func main() {
 	// The string to search for in the downloaded files
 	needle := []byte("26")
 
-	// Generate a stream of URLs from https://example.com/file-0.txt to https://example.com/file-999.txt
+	// Generate a stream of URLs from https://example.com/file-0.txt 
+	// to https://example.com/file-999.txt
 	urls := rill.Generate(func(send func(string), sendErr func(error)) {
 		for i := 0; i < 1000 && ctx.Err() == nil; i++ {
 			send(fmt.Sprintf("https://example.com/file-%d.txt", i))

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ func main() {
 	ctx := context.Background()
 
 	// ID 999 doesn't exist, so fetching will stop after hitting it.
-	err := CheckAllUsersExist(ctx, 3, []int{1, 2, 3, 4, 5, 999, 7, 8, 9, 10})
+	err := CheckAllUsersExist(ctx, 3, []int{1, 2, 3, 4, 5, 999, 7, 8, 9, 10, 11, 12, 13, 14, 15})
 	fmt.Printf("Check result: %v\n", err)
 }
 

--- a/README.md
+++ b/README.md
@@ -393,15 +393,16 @@ func main() {
 // It iterates through all listing pages and uses [Generate] to simplify sending users and errors to the resulting stream.
 // This function is useful both on its own and as part of larger pipelines.
 func StreamUsers(ctx context.Context, query *mockapi.UserQuery) <-chan rill.Try[*mockapi.User] {
-	if query == nil {
-		query = &mockapi.UserQuery{}
-	}
-
 	return rill.Generate(func(send func(*mockapi.User), sendErr func(error)) {
-		for page := 0; ; page++ {
-			query.Page = page
+		var currentQuery mockapi.UserQuery
+		if query != nil {
+			currentQuery = *query
+		}
 
-			users, err := mockapi.ListUsers(ctx, query)
+		for page := 0; ; page++ {
+			currentQuery.Page = page
+
+			users, err := mockapi.ListUsers(ctx, &currentQuery)
 			if err != nil {
 				sendErr(err)
 				return

--- a/README.md
+++ b/README.md
@@ -300,7 +300,6 @@ func main() {
 	needle := []byte("26")
 
 	// Generate a stream of URLs from https://example.com/file-0.txt to https://example.com/file-999.txt
-	// New URLs will stop being generated if the context is canceled
 	urls := rill.Generate(func(send func(string), sendErr func(error)) {
 		for i := 0; i < 1000 && ctx.Err() == nil; i++ {
 			send(fmt.Sprintf("https://example.com/file-%d.txt", i))

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Pipelines typically consist of a sequence of non-blocking channel transformation
 The general rule is: any error occurring anywhere in a pipeline is propagated down to the final stage,
 where it's caught by some blocking function and returned to the caller.
 
-Rill provides a wide selection of blocking functions. Some of them are:
+Rill provides a wide selection of blocking functions. Here are some commonly used ones:
 
 - **ForEach:** Concurrently applies a user function to each item in the stream.
   [Example](https://pkg.go.dev/github.com/destel/rill#example-ForEach)
@@ -274,9 +274,9 @@ func CheckAllUsersExist(ctx context.Context, concurrency int, ids []int) error {
 }
 ```
 
-In the example above only the second stage (`mockapi.GetUser`) of the pipeline is context-aware, 
-which is fine - the input slice is small and the expensive API calls will be prevented anyway.
-For completeness below is a demonstration of how to replace **FromSlice** with **Generate** to make the first stage context-aware as well.
+In the example above only the second stage (`mockapi.GetUser`) of the pipeline is context-aware.
+This approach works well since the input slice is small, iteration is fast and context cancellation prevents expensive API calls regardless.
+The following example demonstrates how to replace **FromSlice** with **Generate** when full context awareness becomes important.
 
 ```go
 idsStream := rill.Generate(func(send func(int), sendErr func(error)) {

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ func CheckAllUsersExist(ctx context.Context, concurrency int, ids []int) error {
 ```
 
 In the example above only the second stage (`mockapi.GetUser`) of the pipeline is context-aware.
-This approach works well since the input slice is small, iteration is fast and context cancellation prevents expensive API calls regardless.
+FromSlice works well here since the input is small, iteration is fast and context cancellation prevents expensive API calls regardless.
 The following example demonstrates how to replace **FromSlice** with **Generate** when full context awareness becomes important.
 
 ```go

--- a/example_test.go
+++ b/example_test.go
@@ -171,7 +171,6 @@ func Example_ordering() {
 	needle := []byte("26")
 
 	// Generate a stream of URLs from https://example.com/file-0.txt to https://example.com/file-999.txt
-	// New URLs will stop being generated if the context is canceled
 	urls := rill.Generate(func(send func(string), sendErr func(error)) {
 		for i := 0; i < 1000 && ctx.Err() == nil; i++ {
 			send(fmt.Sprintf("https://example.com/file-%d.txt", i))

--- a/example_test.go
+++ b/example_test.go
@@ -267,24 +267,20 @@ func Example_flatMap() {
 }
 
 // StreamUsers is a reusable streaming wrapper around the mockapi.ListUsers function.
-// It iterates through all listing pages and returns a stream of users.
+// It iterates through all listing pages and uses [Generate] to simplify sending users and errors to the resulting stream.
 // This function is useful both on its own and as part of larger pipelines.
 func StreamUsers(ctx context.Context, query *mockapi.UserQuery) <-chan rill.Try[*mockapi.User] {
-	res := make(chan rill.Try[*mockapi.User])
-
 	if query == nil {
 		query = &mockapi.UserQuery{}
 	}
 
-	go func() {
-		defer close(res)
-
+	return rill.Generate(func(send func(*mockapi.User), sendErr func(error)) {
 		for page := 0; ; page++ {
 			query.Page = page
 
 			users, err := mockapi.ListUsers(ctx, query)
 			if err != nil {
-				res <- rill.Wrap[*mockapi.User](nil, err)
+				sendErr(err)
 				return
 			}
 
@@ -293,12 +289,10 @@ func StreamUsers(ctx context.Context, query *mockapi.UserQuery) <-chan rill.Try[
 			}
 
 			for _, user := range users {
-				res <- rill.Wrap(user, nil)
+				send(user)
 			}
 		}
-	}()
-
-	return res
+	})
 }
 
 // This example demonstrates how to gracefully stop a pipeline on the first error.

--- a/example_test.go
+++ b/example_test.go
@@ -170,7 +170,8 @@ func Example_ordering() {
 	// The string to search for in the downloaded files
 	needle := []byte("26")
 
-	// Generate a stream of URLs from https://example.com/file-0.txt to https://example.com/file-999.txt
+	// Generate a stream of URLs from https://example.com/file-0.txt
+	// to https://example.com/file-999.txt
 	urls := rill.Generate(func(send func(string), sendErr func(error)) {
 		for i := 0; i < 1000 && ctx.Err() == nil; i++ {
 			send(fmt.Sprintf("https://example.com/file-%d.txt", i))

--- a/example_test.go
+++ b/example_test.go
@@ -301,7 +301,7 @@ func Example_context() {
 	ctx := context.Background()
 
 	// ID 999 doesn't exist, so fetching will stop after hitting it.
-	err := CheckAllUsersExist(ctx, 3, []int{1, 2, 3, 4, 5, 999, 7, 8, 9, 10})
+	err := CheckAllUsersExist(ctx, 3, []int{1, 2, 3, 4, 5, 999, 7, 8, 9, 10, 11, 12, 13, 14, 15})
 	fmt.Printf("Check result: %v\n", err)
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -618,11 +618,11 @@ func ExampleForEach_ordered() {
 	fmt.Println("Error:", err)
 }
 
-// Generate a stream of URLs from http://example.com/file-0.txt to http://example.com/file-9.txt
+// Generate a stream of URLs from https://example.com/file-0.txt to https://example.com/file-9.txt
 func ExampleGenerate() {
 	urls := rill.Generate(func(send func(string), sendErr func(error)) {
 		for i := 0; i < 10; i++ {
-			send(fmt.Sprintf("http://example.com/file-%d.txt", i))
+			send(fmt.Sprintf("https://example.com/file-%d.txt", i))
 		}
 	})
 

--- a/example_test.go
+++ b/example_test.go
@@ -269,15 +269,16 @@ func Example_flatMap() {
 // It iterates through all listing pages and uses [Generate] to simplify sending users and errors to the resulting stream.
 // This function is useful both on its own and as part of larger pipelines.
 func StreamUsers(ctx context.Context, query *mockapi.UserQuery) <-chan rill.Try[*mockapi.User] {
-	if query == nil {
-		query = &mockapi.UserQuery{}
-	}
-
 	return rill.Generate(func(send func(*mockapi.User), sendErr func(error)) {
-		for page := 0; ; page++ {
-			query.Page = page
+		var currentQuery mockapi.UserQuery
+		if query != nil {
+			currentQuery = *query
+		}
 
-			users, err := mockapi.ListUsers(ctx, query)
+		for page := 0; ; page++ {
+			currentQuery.Page = page
+
+			users, err := mockapi.ListUsers(ctx, &currentQuery)
 			if err != nil {
 				sendErr(err)
 				return

--- a/example_test.go
+++ b/example_test.go
@@ -615,6 +615,33 @@ func ExampleForEach_ordered() {
 	fmt.Println("Error:", err)
 }
 
+// Generate a stream of URLs from http://example.com/file-0.txt to http://example.com/file-9.txt
+func ExampleGenerate() {
+	urls := rill.Generate(func(send func(string), sendErr func(error)) {
+		for i := 0; i < 10; i++ {
+			send(fmt.Sprintf("http://example.com/file-%d.txt", i))
+		}
+	})
+
+	printStream(urls)
+}
+
+// Generate an infinite stream of natural numbers (1, 2, 3, ...).
+// New numbers are sent to the stream every 500ms until the context is canceled
+func ExampleGenerate_context() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	numbers := rill.Generate(func(send func(int), sendErr func(error)) {
+		for i := 1; ctx.Err() == nil; i++ {
+			send(i)
+			time.Sleep(500 * time.Millisecond)
+		}
+	})
+
+	printStream(numbers)
+}
+
 func ExampleMap() {
 	// Convert a slice of numbers into a stream
 	numbers := rill.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil)

--- a/wrap.go
+++ b/wrap.go
@@ -182,13 +182,13 @@ func ToChans[A any](in <-chan Try[A]) (<-chan A, <-chan error) {
 //
 // Here's how the same code would look without Generate:
 //
-//	stream := make(chan Try[int])
+//	stream := make(chan rill.Try[int])
 //	go func() {
 //		defer close(stream)
 //		for i := 0; i < 100; i++ {
-//			stream <- Try[int]{Value: i}
+//			stream <- rill.Try[int]{Value: i}
 //		}
-//		stream <- Try[int]{Error: someError}
+//		stream <- rill.Try[int]{Error: someError}
 //	}()
 func Generate[A any](f func(send func(A), sendErr func(error))) <-chan Try[A] {
 	out := make(chan Try[A])

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -180,3 +180,20 @@ func TestFromChans(t *testing.T) {
 	runTest("values and errors", makeSlice(10000), makeErrSlice(10000))
 	runTest("values and nil errors", makeSlice(10), []error{nil, nil, fmt.Errorf("err"), nil})
 }
+
+func TestGenerate(t *testing.T) {
+	in := Generate(func(send func(int), sendErr func(error)) {
+		for i := 0; i < 10; i++ {
+			if i%2 == 0 {
+				send(i)
+			} else {
+				sendErr(fmt.Errorf("err%d", i))
+			}
+		}
+	})
+
+	outSlice, errSlice := toSliceAndErrors(in)
+
+	th.ExpectSlice(t, outSlice, []int{0, 2, 4, 6, 8})
+	th.ExpectSlice(t, errSlice, []string{"err1", "err3", "err5", "err7", "err9"})
+}


### PR DESCRIPTION
Adds a new Generate function that simplifies stream creation by:
- Removing channel/goroutine boilerplate
- Providing ergonomic send/sendErr callbacks
- Managing channel lifecycle automatically


Before:
```go
stream := make(chan rill.Try[int])
go func() {
	defer close(stream)
	for i := 0; i < 100; i++ {
		stream <- rill.Try[int]{Value: i}
	}
	stream <- rill.Try[int]{Error: someError}
}()
```

After:
```go
stream := rill.Generate(func(send func(int), sendErr func(error)) {
	for i := 0; i < 100; i++ {
		send(i)
	}
	sendErr(someError)
})
```