### PR TITLE
Fix lost error in Reduce for single-element streams

### DIFF
--- a/reduce.go
+++ b/reduce.go
@@ -56,7 +56,10 @@ func Reduce[A any](in <-chan Try[A], n int, f func(A, A) (A, error)) (result A, 
 			return Try[A]{Value: res} // the only non-dummy return
 		})
 
-		setReturns(res.Value, ok, nil)
+		if res.Error != nil {
+			ok = false
+		}
+		setReturns(res.Value, ok, res.Error)
 	}()
 
 	once.Wait()

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -24,6 +24,33 @@ func TestReduce(t *testing.T) {
 			th.ExpectDrainedChan(t, in)
 		})
 
+		t.Run(th.Name("single item", n), func(t *testing.T) {
+			t.Run("no error", func(t *testing.T) {
+				in := FromSlice([]int{5}, nil)
+
+				out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
+					return x + y, nil
+				})
+
+				th.ExpectNoError(t, err)
+				th.ExpectValue(t, out, 5)
+				th.ExpectValue(t, ok, true)
+				th.ExpectDrainedChan(t, in)
+			})
+
+			t.Run("error", func(t *testing.T) {
+				in := FromSlice([]int{}, fmt.Errorf("err0"))
+
+				_, ok, err := Reduce(in, n, func(x, y int) (int, error) {
+					return x + y, nil
+				})
+
+				th.ExpectError(t, err, "err0")
+				th.ExpectValue(t, ok, false)
+				th.ExpectDrainedChan(t, in)
+			})
+		})
+
 		t.Run(th.Name("no errors", n), func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 100), nil)
 


### PR DESCRIPTION
When the input stream contained exactly one element and it was an error, Reduce returned nil, true instead of propagating the error. 
Added a test for single-element streams and fixed the bug.
Fixes #71 