### PR TITLE
Add golangci-lint

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -48,3 +48,18 @@ jobs:
           github-token: ${{ secrets.github_token }}
           file: coverage.out
           format: golang
+
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.x'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,8 +3,9 @@ version: "2"
 linters:
   # default = the standard set: errcheck, govet, ineffassign, staticcheck, unused
   enable:
-    - errorlint   
+    - errorlint
     - godoclint
+    - modernize
 
 formatters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,11 @@
+version: "2"
+
+linters:
+  # default = the standard set: errcheck, govet, ineffassign, staticcheck, unused
+  enable:
+    - errorlint   
+    - godoclint
+
+formatters:
+  enable:
+    - goimports

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -46,7 +46,7 @@ func runBenchmark(b *testing.B, name string, body func(in <-chan Try[int])) {
 			b.StartTimer()
 
 			// write to input
-			for k := 0; k < benchmarkInputSize; k++ {
+			for k := range benchmarkInputSize {
 				in <- Try[int]{Value: k}
 			}
 			close(in)

--- a/example_test.go
+++ b/example_test.go
@@ -384,7 +384,7 @@ func ExampleBatch() {
 	numbers := make(chan rill.Try[int])
 	go func() {
 		defer close(numbers)
-		for i := 0; i < 50; i++ {
+		for i := range 50 {
 			numbers <- rill.Wrap(i, nil)
 			time.Sleep(50 * time.Millisecond)
 		}
@@ -630,7 +630,7 @@ func ExampleForEach_ordered() {
 // Generate a stream of URLs from https://example.com/file-0.txt to https://example.com/file-9.txt
 func ExampleGenerate() {
 	urls := rill.Generate(func(send func(string), sendErr func(error)) {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			send(fmt.Sprintf("https://example.com/file-%d.txt", i))
 		}
 	})

--- a/internal/core/loops.go
+++ b/internal/core/loops.go
@@ -22,15 +22,12 @@ func Loop[A, B any](in <-chan A, done chan<- B, n int, f func(A)) {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+	for range n {
+		wg.Go(func() {
 			for a := range in {
 				f(a)
 			}
-		}()
+		})
 	}
 
 	if done != nil {
@@ -105,17 +102,15 @@ func OrderedLoop[A, B any](in <-chan A, done chan<- B, n int, f func(a A, canWri
 	}()
 
 	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range n {
+		wg.Go(func() {
 			for a := range orderedIn {
 				f(a.Value, a.CanWrite)
 
 				releaseCanWriteChan(a.CanWrite)
 				a.NextCanWrite <- struct{}{}
 			}
-		}()
+		})
 	}
 
 	if done != nil {

--- a/internal/core/loops.go
+++ b/internal/core/loops.go
@@ -30,7 +30,6 @@ func Loop[A, B any](in <-chan A, done chan<- B, n int, f func(A)) {
 			for a := range in {
 				f(a)
 			}
-			return
 		}()
 	}
 

--- a/internal/core/merge.go
+++ b/internal/core/merge.go
@@ -57,9 +57,8 @@ func slowMerge[A any](ins []<-chan A) <-chan A {
 
 	var wg sync.WaitGroup
 	for _, in := range ins {
-		in1 := in
 		wg.Go(func() {
-			for x := range in1 {
+			for x := range in {
 				out <- x
 			}
 		})

--- a/internal/core/merge.go
+++ b/internal/core/merge.go
@@ -58,13 +58,11 @@ func slowMerge[A any](ins []<-chan A) <-chan A {
 	var wg sync.WaitGroup
 	for _, in := range ins {
 		in1 := in
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for x := range in1 {
 				out <- x
 			}
-		}()
+		})
 	}
 
 	go func() {

--- a/internal/core/merge_test.go
+++ b/internal/core/merge_test.go
@@ -17,7 +17,7 @@ func TestMerge(t *testing.T) {
 		t.Run(th.Name("correctness", numChans), func(t *testing.T) {
 			ins := make([]<-chan int, numChans)
 
-			for i := 0; i < numChans; i++ {
+			for i := range numChans {
 				ins[i] = th.FromRange(i*10, (i+1)*10)
 			}
 

--- a/internal/core/once_test.go
+++ b/internal/core/once_test.go
@@ -15,7 +15,7 @@ func TestOnceWithWait(t *testing.T) {
 
 		th.ExpectValue(t, o.WasCalled(), false)
 
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			go func() {
 				o.Do(func() {
 					calls.Add(1)

--- a/internal/core/reduce.go
+++ b/internal/core/reduce.go
@@ -34,16 +34,13 @@ func Reduce[A any](in <-chan A, n int, f func(A, A) A) (A, bool) {
 	partialResults := make(chan A, n)
 	var wg sync.WaitGroup
 
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+	for range n {
+		wg.Go(func() {
 			res, ok := nonConcurrentReduce(in, f)
 			if ok {
 				partialResults <- res
 			}
-		}()
+		})
 	}
 
 	go func() {
@@ -110,17 +107,14 @@ func MapReduce[A any, K comparable, V any](in <-chan A, nm int, mapper func(A) (
 	partialResults := make(chan map[K]V, nr)
 	var wg sync.WaitGroup
 
-	for i := 0; i < nr; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+	for range nr {
+		wg.Go(func() {
 			res := make(map[K]V)
 			for kv := range mapped {
 				reduceIntoMap(res, kv.Key, kv.Value, reducer)
 			}
 			partialResults <- res
-		}()
+		})
 	}
 
 	go func() {

--- a/internal/core/reduce_test.go
+++ b/internal/core/reduce_test.go
@@ -11,7 +11,6 @@ import (
 func TestReduce(t *testing.T) {
 	for _, n := range []int{1, 4, 8} {
 		t.Run(th.Name("nil", n), func(t *testing.T) {
-			n := n
 			th.ExpectHang(t, 1*time.Second, func() {
 				_, _ = Reduce[int](nil, n, func(a, b int) int {
 					return a + b

--- a/internal/core/transform_test.go
+++ b/internal/core/transform_test.go
@@ -32,7 +32,7 @@ func TestFilterMap(t *testing.T) {
 				outSlice := th.ToSlice(out)
 
 				expectedSlice := make([]string, 0, 20)
-				for i := 0; i < 20; i++ {
+				for i := range 20 {
 					if i%2 != 0 {
 						continue
 					}

--- a/internal/th/assertions.go
+++ b/internal/th/assertions.go
@@ -2,7 +2,8 @@
 package th
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"testing"
 	"time"
 )
@@ -80,26 +81,16 @@ type number interface {
 	~int | ~int64
 }
 
-type ordered interface {
-	~int | ~int64 | ~string
-}
-
-func ExpectSorted[T ordered](t *testing.T, arr []T) {
+func ExpectSorted[T cmp.Ordered](t *testing.T, arr []T) {
 	t.Helper()
-	isSorted := sort.SliceIsSorted(arr, func(i, j int) bool {
-		return arr[i] <= arr[j]
-	})
-	if !isSorted {
+	if !slices.IsSorted(arr) {
 		t.Errorf("expected sorted slice")
 	}
 }
 
-func ExpectUnsorted[T ordered](t *testing.T, arr []T) {
+func ExpectUnsorted[T cmp.Ordered](t *testing.T, arr []T) {
 	t.Helper()
-	isSorted := sort.SliceIsSorted(arr, func(i, j int) bool {
-		return arr[i] <= arr[j]
-	})
-	if isSorted {
+	if slices.IsSorted(arr) {
 		t.Errorf("expected unsorted slice")
 	}
 }

--- a/internal/th/concurrency_monitor.go
+++ b/internal/th/concurrency_monitor.go
@@ -14,7 +14,6 @@ type ConcurrencyMonitor struct {
 	current int
 	max     int
 
-	target int
 	window time.Duration
 
 	lastChangeAt time.Time

--- a/internal/th/helpers.go
+++ b/internal/th/helpers.go
@@ -1,6 +1,7 @@
 package th
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 	"strings"
@@ -40,7 +41,7 @@ func Send[T any](ch chan<- T, items ...T) {
 	}
 }
 
-func Sort[A ordered](s []A) {
+func Sort[A cmp.Ordered](s []A) {
 	slices.Sort(s)
 }
 

--- a/internal/th/helpers.go
+++ b/internal/th/helpers.go
@@ -2,7 +2,7 @@ package th
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -41,21 +41,16 @@ func Send[T any](ch chan<- T, items ...T) {
 }
 
 func Sort[A ordered](s []A) {
-	sort.Slice(s, func(i, j int) bool {
-		return s[i] < s[j]
-	})
+	slices.Sort(s)
 }
 
 func DoConcurrently(ff ...func()) {
 	var wg sync.WaitGroup
 
 	for _, f := range ff {
-		f := f
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			f()
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -64,13 +59,10 @@ func DoConcurrently(ff ...func()) {
 func DoConcurrentlyN(n int, f func(i int)) {
 	var wg sync.WaitGroup
 
-	for i := 0; i < n; i++ {
-		i := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for i := range n {
+		wg.Go(func() {
 			f(i)
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/iter_test.go
+++ b/iter_test.go
@@ -102,7 +102,7 @@ func TestFromSeq2(t *testing.T) {
 		// generate from 0 to 7, and when the value is  5, yield error
 		err5 := errors.New("err5")
 		gen := func(yield func(x int, err error) bool) {
-			for i := 0; i < 8; i++ {
+			for i := range 8 {
 				var err error
 				if i == 5 {
 					err = err5

--- a/merge_test.go
+++ b/merge_test.go
@@ -66,7 +66,7 @@ func TestSplit2(t *testing.T) {
 				var expectedOutSliceTrue, expectedOutSliceFalse []int
 				var expectedErrSlice []string
 
-				for i := 0; i < 20*4; i++ {
+				for i := range 20 * 4 {
 					switch i % 4 {
 					case 0:
 						expectedOutSliceTrue = append(expectedOutSliceTrue, i)

--- a/mockapi/files.go
+++ b/mockapi/files.go
@@ -13,5 +13,5 @@ func DownloadFile(ctx context.Context, url string) ([]byte, error) {
 		return nil, err
 	}
 
-	return []byte(fmt.Sprintf("This is the content of %s", url)), nil
+	return fmt.Appendf(nil, "This is the content of %s", url), nil
 }

--- a/mockapi/users.go
+++ b/mockapi/users.go
@@ -191,7 +191,7 @@ func getUserIndex(id int) (int, error) {
 
 func hash(input ...any) int {
 	hasher := fnv.New32()
-	fmt.Fprintln(hasher, input...)
+	_, _ = fmt.Fprintln(hasher, input...)
 	return int(hasher.Sum32())
 }
 

--- a/transform_test.go
+++ b/transform_test.go
@@ -42,7 +42,7 @@ func TestMap(t *testing.T) {
 				outSlice, errSlice := toSliceAndErrors(out)
 
 				expectedSlice := make([]string, 0, 20)
-				for i := 0; i < 20; i++ {
+				for i := range 20 {
 					if i == 5 || i == 6 || i == 15 {
 						continue
 					}
@@ -117,7 +117,7 @@ func TestFilter(t *testing.T) {
 				outSlice, errSlice := toSliceAndErrors(out)
 
 				expectedSlice := make([]int, 0, 20)
-				for i := 0; i < 20; i++ {
+				for i := range 20 {
 					if i%2 == 1 || i == 5 || i == 6 || i == 15 {
 						continue
 					}
@@ -195,7 +195,7 @@ func TestFilterMap(t *testing.T) {
 				outSlice, errSlice := toSliceAndErrors(out)
 
 				expectedSlice := make([]string, 0, 20)
-				for i := 0; i < 20; i++ {
+				for i := range 20 {
 					if i == 5 || i == 6 || i == 15 || i%2 == 1 {
 						continue
 					}
@@ -271,7 +271,7 @@ func TestFlatMap(t *testing.T) {
 				outSlice, errSlice := toSliceAndErrors(out)
 
 				expectedSlice := make([]string, 0, 20*2)
-				for i := 0; i < 20; i++ {
+				for i := range 20 {
 					if i == 5 || i == 15 {
 						continue
 					}
@@ -351,7 +351,7 @@ func TestCatch(t *testing.T) {
 				outSlice, errSlice := toSliceAndErrors(out)
 
 				expectedSlice := make([]int, 0, 20)
-				for i := 0; i < 20; i++ {
+				for i := range 20 {
 					if i == 5 || i == 10 || i == 15 {
 						continue
 					}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -57,7 +57,7 @@ func TestFromSlice(t *testing.T) {
 
 	t.Run("errors", func(t *testing.T) {
 		inSlice := make([]int, 20)
-		for i := 0; i < 20; i++ {
+		for i := range 20 {
 			inSlice[i] = i
 		}
 
@@ -85,7 +85,7 @@ func TestFromChan(t *testing.T) {
 		var inSlice []int
 		var expectedOutSlice []Try[int]
 
-		for i := 0; i < 20000; i++ {
+		for i := range 20000 {
 			inSlice = append(inSlice, i)
 			expectedOutSlice = append(expectedOutSlice, Try[int]{Value: i})
 		}
@@ -103,7 +103,7 @@ func TestFromChan(t *testing.T) {
 		err := fmt.Errorf("err")
 		expectedOutSlice = append(expectedOutSlice, Try[int]{Error: err})
 
-		for i := 0; i < 20000; i++ {
+		for i := range 20000 {
 			inSlice = append(inSlice, i)
 			expectedOutSlice = append(expectedOutSlice, Try[int]{Value: i})
 		}
@@ -160,7 +160,7 @@ func TestFromChans(t *testing.T) {
 
 	makeSlice := func(n int) []int {
 		out := make([]int, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			out[i] = i
 		}
 		return out
@@ -168,7 +168,7 @@ func TestFromChans(t *testing.T) {
 
 	makeErrSlice := func(n int) []error {
 		out := make([]error, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			out[i] = fmt.Errorf("err%06d", i)
 		}
 		return out
@@ -183,7 +183,7 @@ func TestFromChans(t *testing.T) {
 
 func TestGenerate(t *testing.T) {
 	in := Generate(func(send func(int), sendErr func(error)) {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			if i%2 == 0 {
 				send(i)
 			} else {


### PR DESCRIPTION
- Add golangci-lint config and run it in CI
- Modernize code (wg.Go, range-over-int, slices.Sort; stdlib slices/cmp in helpers)
- Fix formatting and drop redundant loop-var copies