### PR TITLE
fix: correct typos in doc comments (batch.go, reduce.go)

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -6,7 +6,7 @@ import (
 	"github.com/destel/rill/internal/core"
 )
 
-// Batch take a stream of items and returns a stream of batches based on a maximum size and a timeout.
+// Batch takes a stream of items and returns a stream of batches based on a maximum size and a timeout.
 //
 // A batch is emitted when one of the following conditions is met:
 //   - The batch reaches the maximum size

--- a/internal/core/reduce.go
+++ b/internal/core/reduce.go
@@ -80,7 +80,7 @@ func reduceIntoMap[K comparable, V any](m map[K]V, k K, v V, f func(V, V) V) {
 }
 
 // MapReduce applies a map-reduce pattern to the input channel.
-// First inout is converted into key-value pairs using the mapper function and nm goroutines.
+// First input is converted into key-value pairs using the mapper function and nm goroutines.
 // If there are multiple values for the same key, they are reduced into a single value using the reducer function and nr goroutines.
 // The result is a map where each key is associated with a single value.
 func MapReduce[A any, K comparable, V any](in <-chan A, nm int, mapper func(A) (K, V), nr int, reducer func(V, V) V) map[K]V {


### PR DESCRIPTION
Two minor typos in doc comments:

- `batch.go` line 9: `Batch take` → `Batch takes` (missing trailing *s*; every other exported function in the package uses the conventional `FuncName takes …` form)
- `internal/core/reduce.go` line 83: `inout` → `input` in the `MapReduce` comment (word was accidentally merged)

No logic changes.