### PR TITLE
Deprecate Split2 and OrderedSplit2

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -24,81 +24,77 @@ func Merge[A any](ins ...<-chan A) <-chan A {
 // An ordered version of this function, [OrderedSplit2], is also available.
 //
 // See the package documentation for more information on non-blocking unordered functions and error handling.
+//
+// Deprecated: Split2 will be removed in v1.0. Since the introduction of [Tee]
+// in v0.8, splitting no longer needs a dedicated operation — it can be composed
+// from existing ones. Unlike Split2, the composition is also not limited to two
+// branches.
+//
+// Quite often the predicate is a simple pure check (field comparison, type
+// switch, etc). In such cases splitting is just [Tee] plus a [Filter] on each
+// branch:
+//
+//	adults, minors := rill.Tee(users)
+//	adults = rill.Filter(adults, 1, func(u User) (bool, error) { return u.Age >= 18, nil })
+//	minors = rill.Filter(minors, 1, func(u User) (bool, error) { return u.Age < 18, nil })
+//
+// If the predicate is expensive, stateful, or can fail, it must be evaluated
+// once per item, before [Tee]: inline this function's implementation, which
+// tags each item with the decision and routes on the tag. The same pattern
+// extends to n-way splitting by tagging with an index or key instead of a bool.
 func Split2[A any](in <-chan Try[A], n int, f func(A) (bool, error)) (outTrue <-chan Try[A], outFalse <-chan Try[A]) {
-	if in == nil {
-		return nil, nil
+	type Decision[A any] struct {
+		Value    A
+		Decision bool
 	}
 
-	resOutTrue := make(chan Try[A])
-	resOutFalse := make(chan Try[A])
-	done := make(chan struct{})
-
-	core.Loop(in, done, n, func(a Try[A]) {
-		if a.Error != nil {
-			resOutTrue <- a
-			resOutFalse <- a
-			return
-		}
-
-		isTrue, err := f(a.Value)
-		switch {
-		case err != nil:
-			resOutTrue <- Try[A]{Error: err}
-			resOutFalse <- Try[A]{Error: err}
-		case isTrue:
-			resOutTrue <- a
-		default:
-			resOutFalse <- a
-		}
+	tagged := Map(in, n, func(a A) (Decision[A], error) {
+		d, err := f(a)
+		return Decision[A]{Value: a, Decision: d}, err
 	})
 
-	go func() {
-		<-done
-		close(resOutTrue)
-		close(resOutFalse)
-	}()
+	tagged1, tagged2 := Tee(tagged)
+	outTrue = FilterMap(tagged1, 1, func(d Decision[A]) (A, bool, error) { return d.Value, d.Decision, nil })
+	outFalse = FilterMap(tagged2, 1, func(d Decision[A]) (A, bool, error) { return d.Value, !d.Decision, nil })
 
-	return resOutTrue, resOutFalse
+	return
 }
 
 // OrderedSplit2 is the ordered version of [Split2].
+//
+// Deprecated: OrderedSplit2 will be removed in v1.0. Since the introduction of
+// [Tee] in v0.8, splitting no longer needs a dedicated operation — it can be
+// composed from existing ones. Unlike OrderedSplit2, the composition is also
+// not limited to two branches.
+//
+// Quite often the predicate is a simple pure check (field comparison, type
+// switch, etc). In such cases splitting is just [Tee] plus an [OrderedFilter]
+// on each branch:
+//
+//	adults, minors := rill.Tee(users)
+//	adults = rill.OrderedFilter(adults, 1, func(u User) (bool, error) { return u.Age >= 18, nil })
+//	minors = rill.OrderedFilter(minors, 1, func(u User) (bool, error) { return u.Age < 18, nil })
+//
+// If the predicate is expensive, stateful, or can fail, it must be evaluated
+// once per item, before [Tee]: inline this function's implementation, which
+// tags each item with the decision and routes on the tag. The same pattern
+// extends to n-way splitting by tagging with an index or key instead of a bool.
 func OrderedSplit2[A any](in <-chan Try[A], n int, f func(A) (bool, error)) (outTrue <-chan Try[A], outFalse <-chan Try[A]) {
-	if in == nil {
-		return nil, nil
+	type Decision[A any] struct {
+		Value    A
+		Decision bool
 	}
 
-	resOutTrue := make(chan Try[A])
-	resOutFalse := make(chan Try[A])
-	done := make(chan struct{})
-
-	core.OrderedLoop(in, done, n, func(a Try[A], canWrite <-chan struct{}) {
-		if a.Error != nil {
-			<-canWrite
-			resOutTrue <- a
-			resOutFalse <- a
-			return
-		}
-
-		dir, err := f(a.Value)
-		<-canWrite
-		switch {
-		case err != nil:
-			resOutTrue <- Try[A]{Error: err}
-			resOutFalse <- Try[A]{Error: err}
-		case dir:
-			resOutTrue <- a
-		default:
-			resOutFalse <- a
-		}
+	tagged := OrderedMap(in, n, func(a A) (Decision[A], error) {
+		d, err := f(a)
+		return Decision[A]{Value: a, Decision: d}, err
 	})
 
-	go func() {
-		<-done
-		close(resOutTrue)
-		close(resOutFalse)
-	}()
+	tagged1, tagged2 := Tee(tagged)
+	outTrue = OrderedFilterMap(tagged1, 1, func(d Decision[A]) (A, bool, error) { return d.Value, d.Decision, nil })
+	outFalse = OrderedFilterMap(tagged2, 1, func(d Decision[A]) (A, bool, error) { return d.Value, !d.Decision, nil })
 
-	return resOutTrue, resOutFalse
+	return
 }
 
 // Tee returns two streams that are identical to the input stream (both errors and values).

--- a/util.go
+++ b/util.go
@@ -14,7 +14,7 @@ func Discard[A any](in <-chan A) {
 
 // DrainNB is a non-blocking version of [Drain]. It does draining in a separate goroutine.
 //
-// Deprecated: use [Discard] instead
+// Deprecated: use [Discard] instead. DrainNB will be removed in v1.0.
 func DrainNB[A any](in <-chan A) {
 	core.Discard(in)
 }


### PR DESCRIPTION
Since the introduction of `Tee` in v0.8, splitting no longer needs a dedicated operation — it can be composed from existing ones, and the composition isn't limited to two branches.

**When the predicate is a simple pure check**, splitting is just `Tee` + `Filter` on each branch:

```go
adults, minors := rill.Tee(users)
adults = rill.Filter(adults, 1, func(u User) (bool, error) { return u.Age >= 18, nil })
minors = rill.Filter(minors, 1, func(u User) (bool, error) { return u.Age < 18, nil })
```

**When the predicate is expensive, stateful, or can fail**, evaluate it once per item before `Tee`, tagging each item with the decision and routing on the tag:

```go
type Decision struct {
    Value    User
    Decision bool
}

tagged := rill.Map(users, n, func(u User) (Decision, error) {
    ok, err := isAdult(u)
    return Decision{Value: u, Decision: ok}, err
})

tagged1, tagged2 := rill.Tee(tagged)
adults := rill.FilterMap(tagged1, 1, func(d Decision) (User, bool, error) { return d.Value, d.Decision, nil })
minors := rill.FilterMap(tagged2, 1, func(d Decision) (User, bool, error) { return d.Value, !d.Decision, nil })
```

The same pattern extends to n-way splitting by tagging with an index or key instead of a bool.

The deprecated functions are now implemented as exactly this composition, so the existing Split2 tests validate the migration path until removal in v1.0.

Also mentions the upcoming v1.0 removal in DrainNB's deprecation notice.