### PR TITLE
Fix `First` returning found=true on error

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -58,7 +58,8 @@ func Err[A any](in <-chan Try[A]) error {
 }
 
 // First returns the first item or error encountered in the input stream, whichever comes first.
-// The found return flag is set to false if the stream was empty, otherwise it is set to true.
+// The found return flag reports whether a value was found: it is set to false
+// if the stream was empty or if an error was encountered first.
 //
 // This is a blocking ordered function that processes items sequentially.
 // See the package documentation for more information on blocking ordered functions and error handling.
@@ -66,11 +67,11 @@ func First[A any](in <-chan Try[A]) (value A, found bool, err error) {
 	defer Discard(in)
 
 	for a := range in {
-		return a.Value, true, a.Error
+		return a.Value, a.Error == nil, a.Error
 	}
 
-	found = false
-	return
+	var zero A
+	return zero, false, nil
 }
 
 // Any checks if there is an item in the input stream that satisfies the condition f.

--- a/consume_test.go
+++ b/consume_test.go
@@ -91,12 +91,13 @@ func TestFirst(t *testing.T) {
 	th.RunSynctest(t, "error is first", func(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
 		in = replaceWithError(in, 0, fmt.Errorf("err000"))
-		_, _, err := First(in)
+		_, ok, err := First(in)
 
 		synctest.Wait()
 		th.ExpectDrainedChan(t, in)
 
 		th.ExpectError(t, err, "err000")
+		th.ExpectValue(t, ok, false)
 	})
 
 	t.Run("unclosed", func(t *testing.T) {


### PR DESCRIPTION
When the first item in the stream was an error, `First` returned `found=true` paired with a zero value — any caller checking `found` before `err` would silently use a fabricated zero. The `found` flag now reports whether a value was actually found: false on empty stream or when an error comes first.

This aligns `First` with the convention the rest of the family already follows (`Reduce`'s `hasResult`, and `Any`/`All` after #86): the boolean is false whenever an error is returned.

The existing "error is first" test now pins `found=false`.