### PR TITLE
Rework stream conversions: adapters follow the nature of their inputs

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -11,7 +11,12 @@ func TestBatch(t *testing.T) {
 	// most logic is covered by the chans pkg tests
 
 	th.RunSynctest(t, "correctness", func(t *testing.T) {
-		in := FromChan(th.FromRange(0, 10), fmt.Errorf("err0"))
+		in := Generate(func(send func(int), sendErr func(error)) {
+			sendErr(fmt.Errorf("err0"))
+			for i := range 10 {
+				send(i)
+			}
+		})
 		in = replaceWithError(in, 5, fmt.Errorf("err5"))
 		in = replaceWithError(in, 7, fmt.Errorf("err7"))
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -11,23 +11,20 @@ func TestBatch(t *testing.T) {
 	// most logic is covered by the chans pkg tests
 
 	th.RunSynctest(t, "correctness", func(t *testing.T) {
-		in := Generate(func(send func(int), sendErr func(error)) {
-			sendErr(fmt.Errorf("err0"))
-			for i := range 10 {
-				send(i)
-			}
-		})
+		in := FromChan(th.FromRange(0, 15), nil)
+		in = replaceWithError(in, 0, fmt.Errorf("err0"))
 		in = replaceWithError(in, 5, fmt.Errorf("err5"))
-		in = replaceWithError(in, 7, fmt.Errorf("err7"))
+		in = replaceWithError(in, 10, fmt.Errorf("err10"))
 
 		batches, errs := toSliceAndErrors(Batch(in, 3, -1))
 
-		th.ExpectValue(t, len(batches), 3)
-		th.ExpectSlice(t, batches[0], []int{0, 1, 2})
-		th.ExpectSlice(t, batches[1], []int{3, 4, 6})
-		th.ExpectSlice(t, batches[2], []int{8, 9})
+		th.ExpectValue(t, len(batches), 4)
+		th.ExpectSlice(t, batches[0], []int{1, 2, 3})
+		th.ExpectSlice(t, batches[1], []int{4, 6, 7})
+		th.ExpectSlice(t, batches[2], []int{8, 9, 11})
+		th.ExpectSlice(t, batches[3], []int{12, 13, 14})
 
-		th.ExpectSlice(t, errs, []string{"err0", "err5", "err7"})
+		th.ExpectSlice(t, errs, []string{"err0", "err5", "err10"})
 	})
 
 }

--- a/internal/core/merge.go
+++ b/internal/core/merge.go
@@ -4,55 +4,16 @@ import (
 	"sync"
 )
 
-func fastMerge[A any](ins []<-chan A) <-chan A {
-	// len(ins) must be between 2 and 5
-
-	remaining := len(ins)
-	for len(ins) < 5 {
-		ins = append(ins, nil)
+func Merge[A any](ins ...<-chan A) <-chan A {
+	switch len(ins) {
+	case 0:
+		out := make(chan A)
+		close(out)
+		return out
+	case 1:
+		return ins[0]
 	}
 
-	out := make(chan A)
-
-	go func() {
-		defer close(out)
-
-		var a A
-		var ok bool
-		var i int
-
-		for {
-			if remaining == 0 {
-				return
-			}
-
-			select {
-			case a, ok = <-ins[0]:
-				i = 0
-			case a, ok = <-ins[1]:
-				i = 1
-			case a, ok = <-ins[2]:
-				i = 2
-			case a, ok = <-ins[3]:
-				i = 3
-			case a, ok = <-ins[4]:
-				i = 4
-			}
-
-			if !ok {
-				remaining--
-				ins[i] = nil
-				continue
-			}
-
-			out <- a
-		}
-	}()
-
-	return out
-}
-
-func slowMerge[A any](ins []<-chan A) <-chan A {
 	out := make(chan A)
 
 	var wg sync.WaitGroup
@@ -70,17 +31,4 @@ func slowMerge[A any](ins []<-chan A) <-chan A {
 	}()
 
 	return out
-}
-
-func Merge[A any](ins ...<-chan A) <-chan A {
-	switch len(ins) {
-	case 0:
-		return nil
-	case 1:
-		return ins[0]
-	case 2, 3, 4, 5:
-		return fastMerge(ins)
-	default:
-		return slowMerge(ins)
-	}
 }

--- a/internal/core/merge_test.go
+++ b/internal/core/merge_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestMerge(t *testing.T) {
-	t.Run("empty", func(t *testing.T) {
+	th.RunSynctest(t, "empty", func(t *testing.T) {
 		out := Merge[string]()
-		th.ExpectValue(t, out, nil)
+		th.ExpectDrainedChan(t, out)
 	})
 
 	th.TestVariants(t, "num_chans", []int{1, 3, 5, 10}, func(t *testing.T, numChans int) {

--- a/internal/core/util.go
+++ b/internal/core/util.go
@@ -10,6 +10,10 @@ func Discard[A any](in <-chan A) {
 }
 
 func Buffer[A any](in <-chan A, size int) <-chan A {
+	if in == nil {
+		return nil
+	}
+
 	// we use size-1 since 1 additional item is held on the stack (x variable)
 	out := make(chan A, size-1)
 

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -28,6 +28,10 @@ func TestDiscard(t *testing.T) {
 }
 
 func TestBuffer(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		th.ExpectValue(t, Buffer[string](nil, 2), nil)
+	})
+
 	synctest.Test(t, func(t *testing.T) {
 		trySend := func(ch chan<- int, x int) bool {
 			// Wait for the bubble to settle. It makes the non-blocking send deterministic:

--- a/iter.go
+++ b/iter.go
@@ -17,7 +17,6 @@ func FromSeq[A any](seq iter.Seq[A], err error) <-chan Try[A] {
 		out <- Try[A]{Error: err}
 		close(out)
 		return out
-
 	}
 
 	out := make(chan Try[A])
@@ -43,6 +42,8 @@ func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
 }
 
 // ToSeq2 converts an input stream into an iterator of value-error pairs.
+// Errors are yielded as ordinary pairs and do not stop the iteration;
+// handle them inside the loop.
 //
 // If the caller stops iteration early using break or return, ToSeq2 drains the
 // remaining input in the background, like blocking functions such as [ForEach].

--- a/iter.go
+++ b/iter.go
@@ -5,16 +5,14 @@ import (
 )
 
 // FromSeq converts an iterator into a stream.
-// If err is not nil function returns a stream with a single error.
+// If err is not nil, the function returns a stream with a single error,
+// and the iterator is not consumed.
 //
 // Such function signature allows concise wrapping of functions that return an
 // iterator and an error:
 //
 //	stream := rill.FromSeq(someFunc())
 func FromSeq[A any](seq iter.Seq[A], err error) <-chan Try[A] {
-	if seq == nil && err == nil {
-		return nil
-	}
 	if err != nil {
 		out := make(chan Try[A], 1)
 		out <- Try[A]{Error: err}
@@ -35,10 +33,6 @@ func FromSeq[A any](seq iter.Seq[A], err error) <-chan Try[A] {
 
 // FromSeq2 converts an iterator of value-error pairs into a stream.
 func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
-	if seq == nil {
-		return nil
-	}
-
 	out := make(chan Try[A])
 	go func() {
 		for val, err := range seq {

--- a/iter.go
+++ b/iter.go
@@ -44,8 +44,8 @@ func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
 
 // ToSeq2 converts an input stream into an iterator of value-error pairs.
 //
-// If iteration is stopped by the caller using break or return, ToSeq2 drains
-// the input stream in the background to ensure there's no goroutine leaks.
+// If the caller stops iteration early using break or return, ToSeq2 drains the
+// remaining input in the background, like blocking functions such as [ForEach].
 func ToSeq2[A any](in <-chan Try[A]) iter.Seq2[A, error] {
 	return func(yield func(A, error) bool) {
 		defer Discard(in)

--- a/iter.go
+++ b/iter.go
@@ -5,8 +5,7 @@ import (
 )
 
 // FromSeq converts an iterator into a stream.
-// If err is not nil, the function returns a stream with a single error,
-// and the iterator is not consumed.
+// If err is not nil, the function ignores the passed seq and returns a stream with a single error.
 //
 // Such function signature allows concise wrapping of functions that return an
 // iterator and an error:
@@ -45,12 +44,8 @@ func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
 
 // ToSeq2 converts an input stream into an iterator of value-error pairs.
 //
-// This is a blocking ordered function that processes items sequentially.
-// It does not return on the first encountered error. Instead, it iterates over all value-error
-// pairs, either until the input stream is fully consumed or the loop is broken by the caller.
-// So all error handling, if needed, should be done inside the iterator (for-range loop body).
-//
-// See the package documentation for more information on blocking ordered functions.
+// If iteration is stopped by the caller using break or return, ToSeq2 drains
+// the input stream in the background to ensure there's no goroutine leaks.
 func ToSeq2[A any](in <-chan Try[A]) iter.Seq2[A, error] {
 	return func(yield func(A, error) bool) {
 		defer Discard(in)

--- a/iter_test.go
+++ b/iter_test.go
@@ -88,8 +88,6 @@ func TestToSeq2(t *testing.T) {
 	})
 }
 
-// A nil iterator is not tested: like everywhere in Go, consuming it panics,
-// and a panic in the adapter's background goroutine can't be observed in-process.
 func TestFromSeq(t *testing.T) {
 	th.RunSynctest(t, "no error", func(t *testing.T) {
 		in := slices.Values([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})

--- a/iter_test.go
+++ b/iter_test.go
@@ -88,12 +88,9 @@ func TestToSeq2(t *testing.T) {
 	})
 }
 
+// A nil iterator is not tested: like everywhere in Go, consuming it panics,
+// and a panic in the adapter's background goroutine can't be observed in-process.
 func TestFromSeq(t *testing.T) {
-	t.Run("nils", func(t *testing.T) {
-		in := FromSeq[int](nil, nil)
-		th.ExpectValue(t, in, nil)
-	})
-
 	th.RunSynctest(t, "no error", func(t *testing.T) {
 		in := slices.Values([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 		out := FromSeq(in, nil)
@@ -120,11 +117,6 @@ func TestFromSeq(t *testing.T) {
 }
 
 func TestFromSeq2(t *testing.T) {
-	t.Run("nils", func(t *testing.T) {
-		in := FromSeq2[int](nil)
-		th.ExpectValue(t, in, nil)
-	})
-
 	th.RunSynctest(t, "normal", func(t *testing.T) {
 		// generate from 0 to 9, and when the value is  5, yield error
 		gen := func(yield func(x int, err error) bool) {

--- a/merge.go
+++ b/merge.go
@@ -7,7 +7,7 @@ import (
 // Merge performs a fan-in operation on the list of input channels, returning a single output channel.
 // The resulting channel will contain all items from all inputs,
 // and will be closed when all inputs are exhausted.
-// In particular, merging zero channels returns an already closed channel.
+// In particular, Merge with no arguments returns an already closed channel.
 //
 // This is a non-blocking function that processes items from each input sequentially.
 //

--- a/merge.go
+++ b/merge.go
@@ -6,7 +6,8 @@ import (
 
 // Merge performs a fan-in operation on the list of input channels, returning a single output channel.
 // The resulting channel will contain all items from all inputs,
-// and will be closed when all inputs are fully consumed.
+// and will be closed when all inputs are exhausted.
+// In particular, merging zero channels returns an already closed channel.
 //
 // This is a non-blocking function that processes items from each input sequentially.
 //

--- a/wrap.go
+++ b/wrap.go
@@ -120,6 +120,14 @@ func FromChan[A any](values <-chan A, err error) <-chan Try[A] {
 // errors are skipped.
 // The output stream is closed only when both input channels are exhausted.
 // In particular, if at least one input is nil, the output stream never closes.
+//
+// FromChans can directly adapt a function returning separate value and error
+// channels:
+//
+//	stream := rill.FromChans(someFunc())
+//
+// The returned channels are interpreted according to the lifecycle above; in
+// particular, a nil channel is not treated as absent.
 func FromChans[A any](values <-chan A, errs <-chan error) <-chan Try[A] {
 	if values == nil && errs == nil {
 		return nil

--- a/wrap.go
+++ b/wrap.go
@@ -121,13 +121,9 @@ func FromChan[A any](values <-chan A, err error) <-chan Try[A] {
 // The output stream is closed only when both input channels are exhausted.
 // In particular, if at least one input is nil, the output stream never closes.
 //
-// FromChans can directly adapt a function returning separate value and error
-// channels:
+// Such function signature allows concise wrapping of functions that return two channels:
 //
 //	stream := rill.FromChans(someFunc())
-//
-// The returned channels are interpreted according to the lifecycle above; in
-// particular, a nil channel is not treated as absent.
 func FromChans[A any](values <-chan A, errs <-chan error) <-chan Try[A] {
 	if values == nil && errs == nil {
 		return nil

--- a/wrap.go
+++ b/wrap.go
@@ -33,7 +33,7 @@ func Wrap[A any](value A, err error) Try[A] {
 }
 
 // FromSlice converts a slice into a stream.
-// A non-nil error is added to the stream after all the values.
+// If err is not nil, it is added to the end of the stream.
 //
 // Such function signature allows concise wrapping of functions that return a slice and an error:
 //
@@ -88,8 +88,7 @@ func ToSlice[A any](in <-chan Try[A]) ([]A, error) {
 }
 
 // FromChan converts a regular channel into a stream.
-// If err is not nil, the function returns a stream with a single error,
-// and the channel is not consumed.
+// If err is not nil, the function ignores the passed values and returns a stream with a single error.
 //
 // Such function signature allows concise wrapping of functions that return a channel and an error:
 //
@@ -116,11 +115,11 @@ func FromChan[A any](values <-chan A, err error) <-chan Try[A] {
 	return out
 }
 
-// FromChans creates a stream from two channels: one for values and one for errors.
-// It's an inverse of [ToChans]. Items from both inputs are added to the output stream
-// as they arrive; nil error values are skipped.
+// FromChans creates a stream from independent value and error channels.
+// Items from both inputs are added to the output stream as they arrive, and nil
+// errors are skipped.
 // The output stream is closed only when both input channels are exhausted.
-// In particular, a nil input channel is never exhausted, so the output stream never closes.
+// In particular, if at least one input is nil, the output stream never closes.
 func FromChans[A any](values <-chan A, errs <-chan error) <-chan Try[A] {
 	if values == nil && errs == nil {
 		return nil
@@ -160,7 +159,7 @@ func FromChans[A any](values <-chan A, errs <-chan error) <-chan Try[A] {
 
 // ToChans splits an input stream into two channels: one for values and one for errors.
 // Both output channels are closed when the input stream is exhausted.
-// They must be consumed independently to avoid deadlocks.
+// They must be consumed concurrently to avoid deadlocks.
 func ToChans[A any](in <-chan Try[A]) (<-chan A, <-chan error) {
 	if in == nil {
 		return nil, nil

--- a/wrap.go
+++ b/wrap.go
@@ -115,10 +115,9 @@ func FromChan[A any](values <-chan A, err error) <-chan Try[A] {
 	return out
 }
 
-// FromChans converts a regular channel into a stream.
-// Additionally, this function can take a channel of errors, which will be added to
-// the output stream alongside the values.
-// Either argument can be nil, in which case it is ignored. If both arguments are nil, the function returns nil.
+// FromChans creates a stream from two channels: one for values and one for errors.
+// Items from both are added to the output stream as they arrive; nil errors are skipped.
+// The output stream is closed when both input channels are exhausted.
 //
 // Such function signature allows concise wrapping of functions that return two channels:
 //
@@ -132,29 +131,27 @@ func FromChans[A any](values <-chan A, errs <-chan error) <-chan Try[A] {
 
 	go func() {
 		defer close(out)
-		for {
+
+		cntClosed := 0
+		for cntClosed < 2 {
 			select {
 			case err, ok := <-errs:
-				if ok {
-					if err != nil {
-						out <- Try[A]{Error: err}
-					}
-				} else {
+				if !ok {
+					cntClosed++
 					errs = nil
-					if values == nil && errs == nil {
-						return
-					}
+					continue
+				}
+				if err != nil {
+					out <- Try[A]{Error: err}
 				}
 
 			case v, ok := <-values:
-				if ok {
-					out <- Try[A]{Value: v}
-				} else {
+				if !ok {
+					cntClosed++
 					values = nil
-					if values == nil && errs == nil {
-						return
-					}
+					continue
 				}
+				out <- Try[A]{Value: v}
 			}
 		}
 	}()
@@ -163,7 +160,8 @@ func FromChans[A any](values <-chan A, errs <-chan error) <-chan Try[A] {
 }
 
 // ToChans splits an input stream into two channels: one for values and one for errors.
-// It's an inverse of [FromChans]. Returns two nil channels if the input is nil.
+// Both output channels are closed when the input stream is exhausted.
+// They must be consumed independently to avoid deadlocks.
 func ToChans[A any](in <-chan Try[A]) (<-chan A, <-chan error) {
 	if in == nil {
 		return nil, nil

--- a/wrap.go
+++ b/wrap.go
@@ -117,12 +117,10 @@ func FromChan[A any](values <-chan A, err error) <-chan Try[A] {
 }
 
 // FromChans creates a stream from two channels: one for values and one for errors.
-// Items from both are added to the output stream as they arrive; nil errors are skipped.
-// The output stream is closed when both input channels are exhausted.
-//
-// Such function signature allows concise wrapping of functions that return two channels:
-//
-//	stream := rill.FromChans(someFunc())
+// It's an inverse of [ToChans]. Items from both inputs are added to the output stream
+// as they arrive; nil error values are skipped.
+// The output stream is closed only when both input channels are exhausted.
+// In particular, a nil input channel is never exhausted, so the output stream never closes.
 func FromChans[A any](values <-chan A, errs <-chan error) <-chan Try[A] {
 	if values == nil && errs == nil {
 		return nil

--- a/wrap.go
+++ b/wrap.go
@@ -33,7 +33,7 @@ func Wrap[A any](value A, err error) Try[A] {
 }
 
 // FromSlice converts a slice into a stream.
-// If err is not nil function returns a stream with a single error.
+// A non-nil error is added to the stream after all the values.
 //
 // Such function signature allows concise wrapping of functions that return a slice and an error:
 //
@@ -41,32 +41,35 @@ func Wrap[A any](value A, err error) Try[A] {
 func FromSlice[A any](slice []A, err error) <-chan Try[A] {
 	const maxBufferSize = 512
 
-	if err != nil {
-		out := make(chan Try[A], 1)
-		out <- Try[A]{Error: err}
-		close(out)
-		return out
-	}
-
-	sendAll := func(in []A, out chan Try[A]) {
-		for _, a := range in {
+	sendAll := func(out chan Try[A]) {
+		for _, a := range slice {
 			out <- Try[A]{Value: a}
+		}
+		if err != nil {
+			out <- Try[A]{Error: err}
 		}
 		close(out)
 	}
 
-	if len(slice) <= maxBufferSize {
-		out := make(chan Try[A], len(slice))
-		sendAll(slice, out)
+	size := len(slice)
+	if err != nil {
+		size++
+	}
+
+	if size <= maxBufferSize {
+		out := make(chan Try[A], size)
+		sendAll(out)
 		return out
 	}
 
 	out := make(chan Try[A], maxBufferSize)
-	go sendAll(slice, out)
+	go sendAll(out)
 	return out
 }
 
 // ToSlice converts an input stream into a slice.
+// If the stream contains errors, ToSlice returns the values that precede
+// the first error, along with that error.
 //
 // This is a blocking ordered function that processes items sequentially.
 // See the package documentation for more information on blocking ordered functions and error handling.
@@ -85,7 +88,7 @@ func ToSlice[A any](in <-chan Try[A]) ([]A, error) {
 }
 
 // FromChan converts a regular channel into a stream.
-// Additionally, a non-nil error is added to the output stream alongside the values.
+// Additionally, a non-nil error is added to the output stream before any of the values.
 //
 // Such function signature allows concise wrapping of functions that return a channel and an error:
 //

--- a/wrap.go
+++ b/wrap.go
@@ -88,25 +88,26 @@ func ToSlice[A any](in <-chan Try[A]) ([]A, error) {
 }
 
 // FromChan converts a regular channel into a stream.
-// Additionally, a non-nil error is added to the output stream before any of the values.
+// If err is not nil, the function returns a stream with a single error,
+// and the channel is not consumed.
 //
 // Such function signature allows concise wrapping of functions that return a channel and an error:
 //
 //	stream := rill.FromChan(someFunc())
 func FromChan[A any](values <-chan A, err error) <-chan Try[A] {
-	if values == nil && err == nil {
+	if err != nil {
+		out := make(chan Try[A], 1)
+		out <- Try[A]{Error: err}
+		close(out)
+		return out
+	}
+	if values == nil {
 		return nil
 	}
 
 	out := make(chan Try[A])
 	go func() {
 		defer close(out)
-
-		// error goes first
-		if err != nil {
-			out <- Try[A]{Error: err}
-		}
-
 		for x := range values {
 			out <- Try[A]{Value: x}
 		}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -104,15 +104,9 @@ func TestFromChan(t *testing.T) {
 
 	})
 
-	t.Run("nil with error", func(t *testing.T) {
-		var outSlice []Item[int]
-
-		th.ExpectBlock(t, func(t *testing.T) {
-			out := FromChan[int](nil, fmt.Errorf("err"))
-			for item := range out {
-				outSlice = appendTry(outSlice, item)
-			}
-		})
+	th.RunSynctest(t, "nil with error", func(t *testing.T) {
+		out := FromChan[int](nil, fmt.Errorf("err"))
+		outSlice := toItemSlice(out)
 
 		var expectedSlice []Item[int]
 		expectedSlice = appendErr(expectedSlice, fmt.Errorf("err"))
@@ -133,17 +127,19 @@ func TestFromChan(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "error", func(t *testing.T) {
-		inSlice := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+		in := th.FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 
-		out := FromChan(th.FromSlice(inSlice), fmt.Errorf("some error"))
+		out := FromChan(in, fmt.Errorf("some error"))
 
 		outSlice := toItemSlice(out)
 
 		var expectedSlice []Item[int]
 		expectedSlice = appendErr(expectedSlice, fmt.Errorf("some error"))
-		expectedSlice = appendVal(expectedSlice, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
 		th.ExpectSlice(t, outSlice, expectedSlice)
+
+		// the channel is not consumed
+		th.ExpectValue(t, <-in, 0)
 	})
 }
 

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -15,17 +15,6 @@ func TestWrap(t *testing.T) {
 }
 
 func TestFromSlice(t *testing.T) {
-	th.RunSynctest(t, "error", func(t *testing.T) {
-		out := FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9}, fmt.Errorf("some error"))
-
-		outSlice := toItemSlice(out)
-
-		var expectedSlice []Item[int]
-		expectedSlice = appendErr(expectedSlice, fmt.Errorf("some error"))
-
-		th.ExpectSlice(t, outSlice, expectedSlice)
-	})
-
 	th.TestVariants(t, "input_size", []int{0, 20, 4000}, func(t *testing.T, inputSize int) {
 		th.RunSynctest(t, "no error", func(t *testing.T) {
 			var inSlice []int
@@ -37,6 +26,24 @@ func TestFromSlice(t *testing.T) {
 			}
 
 			out := FromSlice(inSlice, nil)
+			outSlice := toItemSlice(out)
+
+			th.ExpectSlice(t, outSlice, expectedSlice)
+		})
+
+		th.RunSynctest(t, "error", func(t *testing.T) {
+			var inSlice []int
+			var expectedSlice []Item[int]
+
+			err := fmt.Errorf("some error")
+
+			for i := range inputSize {
+				inSlice = append(inSlice, i)
+				expectedSlice = appendVal(expectedSlice, i)
+			}
+			expectedSlice = appendErr(expectedSlice, err)
+
+			out := FromSlice(inSlice, err)
 			outSlice := toItemSlice(out)
 
 			th.ExpectSlice(t, outSlice, expectedSlice)

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -49,6 +49,16 @@ func TestFromSlice(t *testing.T) {
 			th.ExpectSlice(t, outSlice, expectedSlice)
 		})
 	})
+
+	t.Run("round trip", func(t *testing.T) {
+		expectedValues := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+		expectedErr := fmt.Errorf("partial result")
+
+		values, err := ToSlice(FromSlice(expectedValues, expectedErr))
+
+		th.ExpectSlice(t, values, expectedValues)
+		th.ExpectError(t, err, "partial result")
+	})
 }
 
 func TestToSlice(t *testing.T) {
@@ -114,6 +124,21 @@ func TestFromChan(t *testing.T) {
 		th.ExpectSlice(t, outSlice, expectedSlice)
 	})
 
+	th.RunSynctest(t, "non-nil with error", func(t *testing.T) {
+		in := th.FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+
+		out := FromChan(in, fmt.Errorf("some error"))
+		outSlice := toItemSlice(out)
+
+		var expectedSlice []Item[int]
+		expectedSlice = appendErr(expectedSlice, fmt.Errorf("some error"))
+
+		th.ExpectSlice(t, outSlice, expectedSlice)
+
+		// the channel is not consumed
+		th.ExpectValue(t, <-in, 0)
+	})
+
 	th.RunSynctest(t, "no error", func(t *testing.T) {
 		inSlice := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
@@ -124,22 +149,6 @@ func TestFromChan(t *testing.T) {
 		expectedSlice = appendVal(expectedSlice, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
 		th.ExpectSlice(t, outSlice, expectedSlice)
-	})
-
-	th.RunSynctest(t, "error", func(t *testing.T) {
-		in := th.FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-
-		out := FromChan(in, fmt.Errorf("some error"))
-
-		outSlice := toItemSlice(out)
-
-		var expectedSlice []Item[int]
-		expectedSlice = appendErr(expectedSlice, fmt.Errorf("some error"))
-
-		th.ExpectSlice(t, outSlice, expectedSlice)
-
-		// the channel is not consumed
-		th.ExpectValue(t, <-in, 0)
 	})
 }
 
@@ -251,6 +260,16 @@ func TestToChans(t *testing.T) {
 			out, errs := ToChans(in)
 			Discard(out)
 			Discard(errs)
+		})
+	})
+
+	t.Run("non-concurrent consumption", func(t *testing.T) {
+		th.ExpectBlock(t, func(t *testing.T) {
+			in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, fmt.Errorf("err"))
+
+			out, errs := ToChans(in)
+			Drain(out)
+			Drain(errs)
 		})
 	})
 }

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -153,28 +153,66 @@ func TestFromChans(t *testing.T) {
 		th.ExpectValue(t, out, nil)
 	})
 
-	th.RunSynctest(t, "nil values", func(t *testing.T) {
-		out := FromChans[int](nil, th.FromSlice([]error{fmt.Errorf("err001"), fmt.Errorf("err002")}))
-		outSlice, errs := toSliceAndErrors(out)
+	// A nil input is an input that's never closed, so the output stays open forever.
+	t.Run("nil values", func(t *testing.T) {
+		var errs []string
 
-		th.ExpectSlice(t, outSlice, nil)
+		th.ExpectBlock(t, func(t *testing.T) {
+			out := FromChans[int](nil, th.FromSlice([]error{fmt.Errorf("err001"), fmt.Errorf("err002")}))
+			for x := range out {
+				if x.Error != nil {
+					errs = append(errs, x.Error.Error())
+				}
+			}
+		})
+
 		th.ExpectSlice(t, errs, []string{"err001", "err002"})
 	})
 
-	th.RunSynctest(t, "nil errors", func(t *testing.T) {
-		out := FromChans(th.FromSlice([]int{0, 1, 2, 3, 4}), nil)
-		outSlice, errs := toSliceAndErrors(out)
+	t.Run("nil errors", func(t *testing.T) {
+		var outSlice []int
+
+		th.ExpectBlock(t, func(t *testing.T) {
+			out := FromChans(th.FromSlice([]int{0, 1, 2, 3, 4}), nil)
+			for x := range out {
+				outSlice = append(outSlice, x.Value)
+			}
+		})
 
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4})
-		th.ExpectSlice(t, errs, nil)
 	})
 
 	th.RunSynctest(t, "not nil", func(t *testing.T) {
-		out := FromChans(th.FromSlice([]int{0, 1, 2, 3, 4}), th.FromSlice([]error{fmt.Errorf("err001"), fmt.Errorf("err002")}))
+		out := FromChans(
+			th.FromSlice([]int{0, 1, 2, 3, 4}),
+			th.FromSlice([]error{fmt.Errorf("err001"), fmt.Errorf("err002")}),
+		)
 		outSlice, errs := toSliceAndErrors(out)
 
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4})
 		th.ExpectSlice(t, errs, []string{"err001", "err002"})
+	})
+
+	t.Run("unclosed values", func(t *testing.T) {
+		th.ExpectLeak(t, func(t *testing.T) {
+			out := FromChans(
+				th.DontClose(th.FromSlice([]int{0, 1, 2, 3, 4})),
+				th.FromSlice([]error{fmt.Errorf("err001"), fmt.Errorf("err002")}),
+			)
+
+			Discard(out)
+		})
+	})
+
+	t.Run("unclosed errors", func(t *testing.T) {
+		th.ExpectLeak(t, func(t *testing.T) {
+			out := FromChans(
+				th.FromSlice([]int{0, 1, 2, 3, 4}),
+				th.DontClose(th.FromSlice([]error{fmt.Errorf("err001"), fmt.Errorf("err002")})),
+			)
+
+			Discard(out)
+		})
 	})
 }
 
@@ -207,6 +245,17 @@ func TestToChans(t *testing.T) {
 
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 4, 5, 6, 8, 9})
 		th.ExpectSlice(t, errSlice, []string{"err003", "err007"})
+	})
+
+	t.Run("unclosed", func(t *testing.T) {
+		th.ExpectLeak(t, func(t *testing.T) {
+			in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)
+			in = th.DontClose(in)
+
+			out, errs := ToChans(in)
+			Discard(out)
+			Discard(errs)
+		})
 	})
 }
 


### PR DESCRIPTION
Reworked stream conversion functions. The main use case of err-taking signatures is a one-line adaptation of `f() (T, error)` calls, so their semantics follow what such functions usually return: completed results preserve partial data, construction errors leave the source untouched, and independent channels keep normal channel semantics.

- **FromSlice(slice, err)** — emits all values followed by err, preserving partial results returned by APIs such as `os.ReadDir` (previously the values were dropped in case of an error). Also, this makes `ToSlice(FromSlice(s, err))` an exact round trip.
- **FromChan(values, err)** — treats err as a construction error: a non-nil error is emitted alone and values are not consumed (previously the channel was consumed after the error). Matches APIs such as RabbitMQ's `Channel.Consume`, which returns `(nil, err)` when consumer setup fails, enabling `rill.FromChan(ch.Consume(...))`.
- **FromSeq(seq, err)** — same construction-error semantics: a non-nil error wins and the sequence is not invoked. When there's no error, a nil sequence no longer returns a nil stream — it is treated as programmer misuse and panics.
- **FromSeq2(seq)** — errors are yielded in-band rather than returned at construction, so every pair is forwarded and the producer controls when iteration stops. A nil sequence panics as above (previously returned a nil stream).
- **FromChans(values, errs)** — treats both channels as independent inputs and closes only after both are exhausted, like a heterogeneous Merge. A nil channel is therefore never exhausted — reversing the old documented behavior where nil inputs were ignored.
- **Merge(ins...)** — Merge with no arguments returns a closed channel instead of nil: with no inputs, "all exhausted" holds trivially.


