### PR TITLE
Create GitHub releases as drafts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,5 +15,6 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
+          draft: true
           prerelease: ${{ contains(github.ref, '-') }}
           generate_release_notes: true


### PR DESCRIPTION
Tag push now creates a draft release instead of publishing right away. This leaves room for manual edits before anything reaches watchers or Dependabot.