### PR TITLE
Simplify Buffer: size is plain channel capacity

### DIFF
--- a/internal/core/util.go
+++ b/internal/core/util.go
@@ -14,8 +14,7 @@ func Buffer[A any](in <-chan A, size int) <-chan A {
 		return nil
 	}
 
-	// we use size-1 since 1 additional item is held on the stack (x variable)
-	out := make(chan A, size-1)
+	out := make(chan A, size)
 
 	go func() {
 		defer close(out)

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -59,7 +59,7 @@ func TestBuffer(t *testing.T) {
 		// consume all
 		outSlice := th.ToSlice(out)
 
-		// Expecting 11 items, since one more item was buffered on the goroutine stack
+		// Expecting 11 items, since one more item is held by the forwarding goroutine
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 	})
 

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -62,4 +62,11 @@ func TestBuffer(t *testing.T) {
 		// Expecting 11 items, since one more item was buffered on the goroutine stack
 		th.ExpectSlice(t, inBufSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 	})
+
+	// Zero is a valid capacity: the result is an unbuffered passthrough.
+	th.RunSynctest(t, "zero size", func(t *testing.T) {
+		in := th.FromRange(0, 10)
+		out := Buffer(in, 0)
+		th.ExpectSlice(t, th.ToSlice(out), []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	})
 }

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -32,7 +32,7 @@ func TestBuffer(t *testing.T) {
 		th.ExpectValue(t, Buffer[string](nil, 2), nil)
 	})
 
-	synctest.Test(t, func(t *testing.T) {
+	th.RunSynctest(t, "capacity", func(t *testing.T) {
 		trySend := func(ch chan<- int, x int) bool {
 			// Wait for the bubble to settle. It makes the non-blocking send deterministic:
 			// it succeeds iff the buffer has room.
@@ -46,20 +46,20 @@ func TestBuffer(t *testing.T) {
 		}
 
 		in := make(chan int)
-		inBuf := Buffer(in, 2)
+		inBuf := Buffer(in, 10)
 
-		th.ExpectValue(t, trySend(in, 1), true)
-		th.ExpectValue(t, trySend(in, 2), true)
-		th.ExpectValue(t, trySend(in, 3), false)
-
-		x, ok := <-inBuf
-		th.ExpectValue(t, x, 1)
-		th.ExpectValue(t, ok, true)
-
-		th.ExpectValue(t, trySend(in, 4), true)
-
+		// try to write as much as possible w/o any consumer attached
+		for i := range 1000 {
+			if !trySend(in, i) {
+				break
+			}
+		}
 		close(in)
-		inSlice := th.ToSlice(inBuf)
-		th.ExpectSlice(t, inSlice, []int{2, 4})
+
+		// consume all
+		inBufSlice := th.ToSlice(inBuf)
+
+		// Expecting 11 items, since one more item was buffered on the goroutine stack
+		th.ExpectSlice(t, inBufSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 	})
 }

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -46,7 +46,7 @@ func TestBuffer(t *testing.T) {
 		}
 
 		in := make(chan int)
-		inBuf := Buffer(in, 10)
+		out := Buffer(in, 10)
 
 		// try to write as much as possible w/o any consumer attached
 		for i := range 1000 {
@@ -57,10 +57,10 @@ func TestBuffer(t *testing.T) {
 		close(in)
 
 		// consume all
-		inBufSlice := th.ToSlice(inBuf)
+		outSlice := th.ToSlice(out)
 
 		// Expecting 11 items, since one more item was buffered on the goroutine stack
-		th.ExpectSlice(t, inBufSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 	})
 
 	// Zero is a valid capacity: the result is an unbuffered passthrough.

--- a/util.go
+++ b/util.go
@@ -35,8 +35,6 @@ func DrainNB[A any](in <-chan A) {
 //	// Now work with the users channel as usual.
 //	// Up to 100 users can be buffered if subsequent stages of the pipeline are slow.
 func Buffer[A any](in <-chan A, size int) <-chan A {
-	validateMinSize(size, 1)
-
 	return core.Buffer(in, size)
 }
 

--- a/util.go
+++ b/util.go
@@ -26,7 +26,7 @@ func DrainNB[A any](in <-chan A) {
 // Buffer takes a channel of items and returns a buffered channel of exact same items in the same order.
 // This can be useful for preventing write operations on the input channel from blocking, especially if subsequent stages
 // in the processing pipeline are slow.
-// Buffering allows up to size items to be held in memory before back pressure is applied to the upstream producer.
+// Up to size items can be buffered before back pressure is applied to the upstream producer.
 //
 // Typical usage of Buffer might look like this:
 //


### PR DESCRIPTION
Previously, Buffer allocated a channel of capacity size-1 to compensate for the additional item held by the forwarding goroutine. This PR removes that compensation, simplifying the code and making it consistent with the rest of the library, where no stage counts its in-flight item. Since size now means plain channel capacity, zero is a valid value, and Buffer's size validation added in #95 is removed.
