### PR TITLE
FromSlice: document that the slice must not be modified while it is read

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -42,7 +42,7 @@ func Wrap[A any](value A, err error) Try[A] {
 //
 //	stream := rill.FromSlice(someFunc())
 func FromSlice[A any](slice []A, err error) <-chan Try[A] {
-	const maxBufferSize = 512
+	const maxBufferSize = 64
 
 	sendAll := func(out chan Try[A]) {
 		for _, a := range slice {

--- a/wrap.go
+++ b/wrap.go
@@ -35,6 +35,9 @@ func Wrap[A any](value A, err error) Try[A] {
 // FromSlice converts a slice into a stream.
 // If err is not nil, it is added to the end of the stream.
 //
+// The slice is read in the background until the returned stream
+// is fully consumed. Modifying it before is a data race.
+//
 // Such function signature allows concise wrapping of functions that return a slice and an error:
 //
 //	stream := rill.FromSlice(someFunc())


### PR DESCRIPTION
Also reduces the internal buffer from 512 to 64 items. Implementation detail, saves some memory.