### PR TITLE
Try container is a value or an error, not both

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -68,21 +68,21 @@ func Err[A any](in <-chan Try[A]) error {
 	return nil
 }
 
-// First returns the first item or error encountered in the input stream, whichever comes first.
-// The found return flag is set to false if the stream was empty or if the first item was an error,
-// otherwise it is set to true.
+// First returns the first value or error encountered in the input stream.
+// If the stream is empty or its first item is an error, found is false and
+// value is the zero value of A.
 //
 // This is a blocking ordered function that processes items sequentially.
 // See the package documentation for more information on blocking ordered functions and error handling.
 func First[A any](in <-chan Try[A]) (value A, found bool, err error) {
 	defer Discard(in)
 
-	for a := range in {
-		return a.Value, a.Error == nil, a.Error
-	}
-
 	var zero A
-	return zero, false, nil
+	a, ok := <-in
+	if !ok || a.Error != nil {
+		return zero, false, a.Error
+	}
+	return a.Value, true, nil
 }
 
 // errFound is a control-flow sentinel, compared by identity - the fs.SkipDir

--- a/consume_test.go
+++ b/consume_test.go
@@ -117,6 +117,18 @@ func TestFirst(t *testing.T) {
 		th.ExpectDrainedChan(t, in)
 	})
 
+	t.Run("value alongside error", func(t *testing.T) {
+		in := make(chan Try[int], 1)
+		in <- Try[int]{Value: 10, Error: fmt.Errorf("err")}
+		close(in)
+
+		x, ok, err := First(in)
+
+		th.ExpectValue(t, x, 0) // zeroed
+		th.ExpectValue(t, ok, false)
+		th.ExpectError(t, err, "err")
+	})
+
 	t.Run("unclosed", func(t *testing.T) {
 		th.ExpectLeak(t, func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 20), nil)

--- a/doc.go
+++ b/doc.go
@@ -5,7 +5,8 @@
 //
 // # Streams and Try Containers
 //
-// In this package, a stream refers to a channel of [Try] containers. A Try container is a simple struct that holds a value and an error.
+// In this package, a stream is a channel of [Try] containers.
+// Each Try represents either a value or an error.
 // When an "empty stream" is referred to, it means a channel of Try containers that has been closed and was never written to.
 //
 // Most functions in this package are concurrent, and the level of concurrency can be controlled by the argument n.

--- a/iter.go
+++ b/iter.go
@@ -32,6 +32,7 @@ func FromSeq[A any](seq iter.Seq[A], err error) <-chan Try[A] {
 }
 
 // FromSeq2 converts an iterator of value-error pairs into a stream.
+// For pairs with a non-nil error, FromSeq2 emits an error item and ignores the value.
 func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
 	validateNilFunc(seq == nil)
 

--- a/iter_test.go
+++ b/iter_test.go
@@ -131,13 +131,11 @@ func TestFromSeq2(t *testing.T) {
 		gen := func(yield func(x int, err error) bool) {
 			for i := range 10 {
 				var err error
-				var val = i
 
 				if i == 5 {
-					val = 0
 					err = fmt.Errorf("err5")
 				}
-				if !yield(val, err) {
+				if !yield(i, err) {
 					break
 				}
 			}

--- a/wrap.go
+++ b/wrap.go
@@ -1,6 +1,7 @@
 package rill
 
-// Try is a container holding a value of type A or an error
+// Try represents either a value of type A or an error.
+// When Error is non-nil, callers must ignore Value.
 type Try[A any] struct {
 	Value A
 	Error error
@@ -22,14 +23,18 @@ type Try[A any] struct {
 //	}
 type Stream[T any] = <-chan Try[T]
 
-// Wrap converts a value and/or error into a [Try] container.
+// Wrap converts a value-error pair into a [Try].
+// If err is non-nil, Wrap returns an error item and ignores value.
 // It's a convenience function to avoid creating a [Try] container manually and benefit from type inference.
 //
 // Such function signature also allows concise wrapping of functions that return a value and an error:
 //
-//	item := rill.Wrap(strconv.ParseInt("42"))
+//	item := rill.Wrap(strconv.Atoi("42"))
 func Wrap[A any](value A, err error) Try[A] {
-	return Try[A]{Value: value, Error: err}
+	if err != nil {
+		return Try[A]{Error: err}
+	}
+	return Try[A]{Value: value}
 }
 
 // FromSlice converts a slice into a stream.

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -9,8 +9,12 @@ import (
 )
 
 func TestWrap(t *testing.T) {
-	item := Wrap(10, fmt.Errorf("err"))
+	item := Wrap(10, nil)
 	th.ExpectValue(t, item.Value, 10)
+	th.ExpectNoError(t, item.Error)
+
+	item = Wrap(10, fmt.Errorf("err"))
+	th.ExpectValue(t, item.Value, 0)
 	th.ExpectError(t, item.Error, "err")
 }
 


### PR DESCRIPTION
Technically, the `Try[T]` container is a plain struct that can carry both a value **and** an error at the same time.
Semantically, rill has always treated such a container as a value **or** an error:

- Callbacks passed to transformations and consumers never receive a value sitting next to a non-nil error
- Such values are destroyed by `Map` and most other transformations

This PR documents these semantics, and makes two changes that, while technically breaking,
are unobservable in 99% of cases (unless code manually consumes a stream with a `for` loop
and reads values sitting next to non-nil errors, or unconditionally consumes the output of `First`):

- Functions that construct streams or containers now ignore the passed value if the error is non-nil: `Wrap`, `FromSeq2`
- `First` now returns a zero value when the first item is an error