### PR TITLE
Ignore nil errors in Generate

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -34,7 +34,7 @@ func TestBatch(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "with timeout", func(t *testing.T) {
-		in := Generate(func(send func(int), sendErr func(error)) {
+		in := Generate(func(send func(int), sendError func(error)) {
 			// flush by size: the mid-batch pause is too short to trigger the timeout
 			send(11)
 			send(12)
@@ -56,7 +56,7 @@ func TestBatch(t *testing.T) {
 			send(31)
 			time.Sleep(4 * time.Second)
 			send(32)
-			sendErr(fmt.Errorf("err1"))
+			sendError(fmt.Errorf("err1"))
 
 			// flush by timeout again: the error disarmed the previous deadline,
 			// otherwise [41] would have flushed alone before 42 arrived
@@ -66,8 +66,8 @@ func TestBatch(t *testing.T) {
 			time.Sleep(4 * time.Second)
 
 			// errors hitting an empty batch are forwarded alone
-			sendErr(fmt.Errorf("err2"))
-			sendErr(fmt.Errorf("err3"))
+			sendError(fmt.Errorf("err2"))
+			sendError(fmt.Errorf("err3"))
 
 			// trailing partial is flushed when the input closes
 			send(51)
@@ -83,7 +83,7 @@ func TestBatch(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "no timeout", func(t *testing.T) {
-		in := Generate(func(send func(int), sendErr func(error)) {
+		in := Generate(func(send func(int), sendError func(error)) {
 			// flush by size: sleep has no effect
 			send(11)
 			send(12)
@@ -94,11 +94,11 @@ func TestBatch(t *testing.T) {
 			// flush by error: the partial batch is flushed first, then the error is forwarded
 			send(21)
 			send(22)
-			sendErr(fmt.Errorf("err1"))
+			sendError(fmt.Errorf("err1"))
 
 			// errors hitting an empty batch are forwarded alone
-			sendErr(fmt.Errorf("err2"))
-			sendErr(fmt.Errorf("err3"))
+			sendError(fmt.Errorf("err2"))
+			sendError(fmt.Errorf("err3"))
 
 			// trailing partial is flushed when the input closes
 			send(31)
@@ -120,12 +120,12 @@ func TestUnbatch(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "correctness", func(t *testing.T) {
-		in := Generate(func(send func([]int), sendErr func(error)) {
+		in := Generate(func(send func([]int), sendError func(error)) {
 			send([]int{1, 2})
-			sendErr(fmt.Errorf("err1"))
+			sendError(fmt.Errorf("err1"))
 			send([]int{10, 11, 12})
 			send([]int{13, 14})
-			sendErr(fmt.Errorf("err2"))
+			sendError(fmt.Errorf("err2"))
 			send([]int{20, 21})
 		})
 
@@ -138,15 +138,15 @@ func TestUnbatch(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "inverse of Batch", func(t *testing.T) {
-		in := Generate(func(send func(int), sendErr func(error)) {
+		in := Generate(func(send func(int), sendError func(error)) {
 			send(0)
 			send(1)
 			send(2)
 			send(3)
 			send(4)
-			sendErr(fmt.Errorf("err5"))
+			sendError(fmt.Errorf("err5"))
 			send(6)
-			sendErr(fmt.Errorf("err7"))
+			sendError(fmt.Errorf("err7"))
 			send(8)
 			send(9)
 		})

--- a/example_test.go
+++ b/example_test.go
@@ -181,7 +181,7 @@ func Example_ordering() {
 	// Generate a stream of URLs from https://example.com/file-0.txt
 	// to https://example.com/file-999.txt
 	// Stop generating URLs if the context is canceled
-	urls := rill.Generate(func(send func(string), sendErr func(error)) {
+	urls := rill.Generate(func(send func(string), sendError func(error)) {
 		for i := 0; i < 1000 && ctx.Err() == nil; i++ {
 			send(fmt.Sprintf("https://example.com/file-%d.txt", i))
 		}
@@ -243,7 +243,7 @@ func Example_flatMap() {
 // It iterates through all listing pages and uses [Generate] to simplify sending users and errors to the resulting stream.
 // This function is useful both on its own and as part of larger pipelines.
 func StreamUsers(ctx context.Context, query *mockapi.UserQuery) <-chan rill.Try[*mockapi.User] {
-	return rill.Generate(func(send func(*mockapi.User), sendErr func(error)) {
+	return rill.Generate(func(send func(*mockapi.User), sendError func(error)) {
 		var currentQuery mockapi.UserQuery
 		if query != nil {
 			currentQuery = *query
@@ -254,7 +254,7 @@ func StreamUsers(ctx context.Context, query *mockapi.UserQuery) <-chan rill.Try[
 
 			users, err := mockapi.ListUsers(ctx, &currentQuery)
 			if err != nil {
-				sendErr(err)
+				sendError(err)
 				return
 			}
 
@@ -288,7 +288,7 @@ func CheckAllUsersExist(ctx context.Context, concurrency int, ids []int) error {
 
 	// Convert the slice into a stream
 	// Use Generate instead of FromSlice to make the first stage context-aware
-	idsStream := rill.Generate(func(send func(int), sendErr func(error)) {
+	idsStream := rill.Generate(func(send func(int), sendError func(error)) {
 		for _, id := range ids {
 			if ctx.Err() != nil {
 				return
@@ -345,7 +345,7 @@ func ExampleAny() {
 // Also check out the package level examples to see Batch in action
 func ExampleBatch() {
 	// Generate a stream of numbers 0 to 49, where a new number is emitted every 50ms
-	numbers := rill.Generate(func(send func(int), sendErr func(error)) {
+	numbers := rill.Generate(func(send func(int), sendError func(error)) {
 		for i := range 50 {
 			send(i)
 			time.Sleep(50 * time.Millisecond)
@@ -591,7 +591,7 @@ func ExampleForEach_ordered() {
 
 // Generate a stream of URLs from https://example.com/file-0.txt to https://example.com/file-9.txt
 func ExampleGenerate() {
-	urls := rill.Generate(func(send func(string), sendErr func(error)) {
+	urls := rill.Generate(func(send func(string), sendError func(error)) {
 		for i := range 10 {
 			send(fmt.Sprintf("https://example.com/file-%d.txt", i))
 		}
@@ -606,7 +606,7 @@ func ExampleGenerate_context() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	numbers := rill.Generate(func(send func(int), sendErr func(error)) {
+	numbers := rill.Generate(func(send func(int), sendError func(error)) {
 		for i := 1; ctx.Err() == nil; i++ {
 			send(i)
 			time.Sleep(500 * time.Millisecond)

--- a/transform_test.go
+++ b/transform_test.go
@@ -259,14 +259,14 @@ func TestFlatMap(t *testing.T) {
 				out := universalFlatMap(ord, in, n, func(x int) <-chan Try[string] {
 					th.SimulateWork(1*time.Second, 2*time.Second)
 
-					return Generate(func(send func(string), sendErr func(error)) {
+					return Generate(func(send func(string), sendError func(error)) {
 						send(fmt.Sprintf("%03dA", x))
-						sendErr(fmt.Errorf("err%03dA", x))
+						sendError(fmt.Errorf("err%03dA", x))
 
 						th.SimulateWork(1*time.Second, 2*time.Second)
 
 						send(fmt.Sprintf("%03dB", x))
-						sendErr(fmt.Errorf("err%03dB", x))
+						sendError(fmt.Errorf("err%03dB", x))
 					})
 				})
 
@@ -295,9 +295,9 @@ func TestFlatMap(t *testing.T) {
 						time.Sleep(10 * time.Second) // force out-of-order completion
 					}
 
-					return Generate(func(send func(string), sendErr func(error)) {
+					return Generate(func(send func(string), sendError func(error)) {
 						send(fmt.Sprintf("%03d-A", x))
-						sendErr(fmt.Errorf("%03d-A-err", x))
+						sendError(fmt.Errorf("%03d-A-err", x))
 
 						if x%9 == 0 {
 							// A gap between this item's A and B outputs, so the assertions below also
@@ -306,7 +306,7 @@ func TestFlatMap(t *testing.T) {
 						}
 
 						send(fmt.Sprintf("%03d-B", x))
-						sendErr(fmt.Errorf("%03d-B-err", x))
+						sendError(fmt.Errorf("%03d-B-err", x))
 					})
 				})
 

--- a/wrap.go
+++ b/wrap.go
@@ -198,6 +198,7 @@ func ToChans[A any](in <-chan Try[A]) (<-chan A, <-chan error) {
 
 // Generate is a shorthand for creating streams.
 // It provides a more ergonomic way of sending both values and errors to a stream, manages goroutine and channel lifecycle.
+// Nil errors passed to sendErr are skipped.
 //
 //	stream := rill.Generate(func(send func(int), sendErr func(error)) {
 //		for i := 0; i < 100; i++ {
@@ -227,7 +228,9 @@ func Generate[A any](f func(send func(A), sendErr func(error))) <-chan Try[A] {
 			out <- Try[A]{Value: a}
 		}
 		sendErr := func(err error) {
-			out <- Try[A]{Error: err}
+			if err != nil {
+				out <- Try[A]{Error: err}
+			}
 		}
 
 		f(send, sendErr)

--- a/wrap.go
+++ b/wrap.go
@@ -198,13 +198,13 @@ func ToChans[A any](in <-chan Try[A]) (<-chan A, <-chan error) {
 
 // Generate is a shorthand for creating streams.
 // It provides a more ergonomic way of sending both values and errors to a stream, manages goroutine and channel lifecycle.
-// Nil errors passed to sendErr are skipped.
+// Nil errors passed to sendError are skipped.
 //
-//	stream := rill.Generate(func(send func(int), sendErr func(error)) {
+//	stream := rill.Generate(func(send func(int), sendError func(error)) {
 //		for i := 0; i < 100; i++ {
 //			send(i)
 //		}
-//		sendErr(someError)
+//		sendError(someError)
 //	})
 //
 // Here's how the same code would look without Generate:
@@ -217,7 +217,7 @@ func ToChans[A any](in <-chan Try[A]) (<-chan A, <-chan error) {
 //		}
 //		stream <- rill.Try[int]{Error: someError}
 //	}()
-func Generate[A any](f func(send func(A), sendErr func(error))) <-chan Try[A] {
+func Generate[A any](f func(send func(A), sendError func(error))) <-chan Try[A] {
 	validateNilFunc(f == nil)
 
 	out := make(chan Try[A])
@@ -227,13 +227,13 @@ func Generate[A any](f func(send func(A), sendErr func(error))) <-chan Try[A] {
 		send := func(a A) {
 			out <- Try[A]{Value: a}
 		}
-		sendErr := func(err error) {
+		sendError := func(err error) {
 			if err != nil {
 				out <- Try[A]{Error: err}
 			}
 		}
 
-		f(send, sendErr)
+		f(send, sendError)
 	}()
 	return out
 }

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -280,11 +280,11 @@ func TestToChans(t *testing.T) {
 
 func TestGenerate(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		in := Generate(func(send func(int), sendErr func(error)) {
+		in := Generate(func(send func(int), sendError func(error)) {
 			send(1)
-			sendErr(fmt.Errorf("err1"))
+			sendError(fmt.Errorf("err1"))
 			send(2)
-			sendErr(nil) // skipped: produces no item
+			sendError(nil) // skipped: produces no item
 			send(3)
 		})
 

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -281,25 +281,20 @@ func TestToChans(t *testing.T) {
 func TestGenerate(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		in := Generate(func(send func(int), sendErr func(error)) {
-			for i := range 10 {
-				if i%2 == 0 {
-					send(i)
-				} else {
-					sendErr(fmt.Errorf("err%d", i))
-				}
-			}
+			send(1)
+			sendErr(fmt.Errorf("err1"))
+			send(2)
+			sendErr(nil) // skipped: produces no item
+			send(3)
 		})
 
 		outSlice := toItemSlice(in)
 
 		var expectedSlice []Item[int]
-		for i := range 10 {
-			if i%2 == 0 {
-				expectedSlice = appendVal(expectedSlice, i)
-			} else {
-				expectedSlice = appendErr(expectedSlice, fmt.Errorf("err%d", i))
-			}
-		}
+		expectedSlice = appendVal(expectedSlice, 1)
+		expectedSlice = appendErr(expectedSlice, fmt.Errorf("err1"))
+		expectedSlice = appendVal(expectedSlice, 2)
+		expectedSlice = appendVal(expectedSlice, 3)
 
 		th.ExpectSlice(t, outSlice, expectedSlice)
 	})


### PR DESCRIPTION
Passing a nil error to `sendErr` used to emit a zero-valued success item; now such calls emit nothing.

Also, this PR does a non-breaking rename of the callback: `sendErr` → `sendError`