### PR TITLE
Ignore nil channels in Discard

### DIFF
--- a/internal/core/util.go
+++ b/internal/core/util.go
@@ -6,6 +6,10 @@ func Drain[A any](in <-chan A) {
 }
 
 func Discard[A any](in <-chan A) {
+	if in == nil {
+		return
+	}
+
 	// do nothing if the channel is already closed
 	select {
 	case _, ok := <-in:

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -16,6 +16,10 @@ func TestDrain(t *testing.T) {
 }
 
 func TestDiscard(t *testing.T) {
+	th.RunSynctest(t, "nil", func(t *testing.T) {
+		Discard[int](nil) // leak would be caught by the bubble
+	})
+
 	th.RunSynctest(t, "normal", func(t *testing.T) {
 		in := make(chan int)
 		Discard(in) // doesn't block


### PR DESCRIPTION
The behavior is now consistent with other non-blocking stages.