### PR TITLE
Add pipeline settlement signal

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -98,7 +98,7 @@ var errFound = errors.New("found")
 // When n = 1, items are processed sequentially in stream order.
 //
 // See the package documentation for more information on blocking unordered functions and error handling.
-func Any[A any](in <-chan Try[A], n int, f func(A) (bool, error)) (bool, error) {
+func Any[A any](in <-chan Try[A], n int, f func(A) (bool, error), options ...SinkOption) (bool, error) {
 	validateN(n)
 	validateNilFunc(f == nil)
 
@@ -111,7 +111,7 @@ func Any[A any](in <-chan Try[A], n int, f func(A) (bool, error)) (bool, error) 
 			return errFound
 		}
 		return nil
-	})
+	}, options...)
 
 	if err == errFound { //nolint:errorlint
 		return true, nil
@@ -127,7 +127,7 @@ func Any[A any](in <-chan Try[A], n int, f func(A) (bool, error)) (bool, error) 
 // When n = 1, items are processed sequentially in stream order.
 //
 // See the package documentation for more information on blocking unordered functions and error handling.
-func All[A any](in <-chan Try[A], n int, f func(A) (bool, error)) (bool, error) {
+func All[A any](in <-chan Try[A], n int, f func(A) (bool, error), options ...SinkOption) (bool, error) {
 	validateN(n)
 	validateNilFunc(f == nil)
 
@@ -140,7 +140,7 @@ func All[A any](in <-chan Try[A], n int, f func(A) (bool, error)) (bool, error) 
 			return errFound
 		}
 		return nil
-	})
+	}, options...)
 
 	if err == errFound { //nolint:errorlint
 		return false, nil

--- a/consume.go
+++ b/consume.go
@@ -14,7 +14,7 @@ import (
 // and all its effects are visible to the caller after ForEach returns.
 //
 // See the package documentation for more information on blocking unordered functions and error handling.
-func ForEach[A any](in <-chan Try[A], n int, f func(A) error) error {
+func ForEach[A any](in <-chan Try[A], n int, f func(A) error, options ...SinkOption) error {
 	validateN(n)
 	validateNilFunc(f == nil)
 
@@ -25,7 +25,7 @@ func ForEach[A any](in <-chan Try[A], n int, f func(A) error) error {
 	//   - return only after the loop exits, so state captured by f is safe
 	//     to use after ForEach returns
 	if n == 1 {
-		defer Discard(in)
+		defer Discard(in, options...)
 
 		for a := range in {
 			err := a.Error
@@ -49,15 +49,15 @@ func ForEach[A any](in <-chan Try[A], n int, f func(A) error) error {
 		return struct{}{}, false, f(a)
 	})
 
-	return Err(out)
+	return Err(out, options...)
 }
 
 // Err returns the first error encountered in the input stream or nil if there were no errors.
 //
 // This is a blocking ordered function that processes items sequentially.
 // See the package documentation for more information on blocking ordered functions and error handling.
-func Err[A any](in <-chan Try[A]) error {
-	defer Discard(in)
+func Err[A any](in <-chan Try[A], options ...SinkOption) error {
+	defer Discard(in, options...)
 
 	for a := range in {
 		if a.Error != nil {
@@ -74,8 +74,8 @@ func Err[A any](in <-chan Try[A]) error {
 //
 // This is a blocking ordered function that processes items sequentially.
 // See the package documentation for more information on blocking ordered functions and error handling.
-func First[A any](in <-chan Try[A]) (value A, found bool, err error) {
-	defer Discard(in)
+func First[A any](in <-chan Try[A], options ...SinkOption) (value A, found bool, err error) {
+	defer Discard(in, options...)
 
 	var zero A
 	a, ok := <-in

--- a/consume_test.go
+++ b/consume_test.go
@@ -18,26 +18,18 @@ func TestErr(t *testing.T) {
 
 	th.RunSynctest(t, "empty", func(t *testing.T) {
 		in := FromSlice([]int{}, nil)
-
-		settled, opt := Settlement()
-		err := Err(in, opt)
+		err := Err(in)
 
 		th.ExpectNoError(t, err)
 		th.ExpectDrainedChan(t, in)
-
-		<-settled // should not leak
 	})
 
 	th.RunSynctest(t, "no errors", func(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
-
-		settled, opt := Settlement()
-		err := Err(in, opt)
+		err := Err(in)
 
 		th.ExpectNoError(t, err)
 		th.ExpectDrainedChan(t, in)
-
-		<-settled // should not leak
 	})
 
 	th.RunSynctest(t, "error", func(t *testing.T) {
@@ -46,13 +38,12 @@ func TestErr(t *testing.T) {
 		in = replaceWithError(in, 15, fmt.Errorf("err015"))
 		in = th.DelayEach(in, 1)
 
-		settled, opt := Settlement()
-		err := Err(in, opt)
+		err := Err(in)
 
 		th.ExpectError(t, err, "err010")
 		th.ExpectOpenChan(t, in)
 
-		<-settled
+		time.Sleep(24 * time.Hour) // eventually drained
 
 		th.ExpectDrainedChan(t, in)
 	})
@@ -68,6 +59,34 @@ func TestErr(t *testing.T) {
 			th.ExpectError(t, err, "err010")
 		})
 	})
+
+	th.RunSynctest(t, "settlement", func(t *testing.T) {
+		in := FromChan(th.FromRange(0, 20), nil)
+
+		settled, opt := Settlement()
+		err := Err(in, opt)
+
+		th.ExpectNoError(t, err)
+		th.ExpectDrainedChan(t, in)
+
+		<-settled // should not leak
+	})
+
+	th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+		in := FromChan(th.FromRange(0, 20), nil)
+		in = replaceWithError(in, 10, fmt.Errorf("err010"))
+		in = th.DelayEach(in, 1)
+
+		settled, opt := Settlement()
+		err := Err(in, opt)
+
+		th.ExpectError(t, err, "err010")
+		th.ExpectOpenChan(t, in)
+
+		<-settled
+
+		th.ExpectDrainedChan(t, in)
+	})
 }
 
 func TestFirst(t *testing.T) {
@@ -80,15 +99,13 @@ func TestFirst(t *testing.T) {
 	th.RunSynctest(t, "empty", func(t *testing.T) {
 		in := FromSlice([]int{}, nil)
 
-		settled, opt := Settlement()
-		_, ok, err := First(in, opt)
+		x, ok, err := First(in)
 
 		th.ExpectNoError(t, err)
 		th.ExpectValue(t, ok, false)
+		th.ExpectValue(t, x, 0)
 
 		th.ExpectDrainedChan(t, in)
-
-		<-settled // should not leak
 	})
 
 	th.RunSynctest(t, "value is first", func(t *testing.T) {
@@ -96,16 +113,14 @@ func TestFirst(t *testing.T) {
 		in = replaceWithError(in, 10, fmt.Errorf("err010"))
 		in = th.DelayEach(in, 1)
 
-		settled, opt := Settlement()
-		x, ok, err := First(in, opt)
+		x, ok, err := First(in)
 
 		th.ExpectNoError(t, err)
 		th.ExpectValue(t, ok, true)
 		th.ExpectValue(t, x, 0)
-
 		th.ExpectOpenChan(t, in)
 
-		<-settled
+		time.Sleep(24 * time.Hour) // eventually drained
 
 		th.ExpectDrainedChan(t, in)
 	})
@@ -115,16 +130,14 @@ func TestFirst(t *testing.T) {
 		in = replaceWithError(in, 0, fmt.Errorf("err000"))
 		in = th.DelayEach(in, 1)
 
-		settled, opt := Settlement()
-		x, ok, err := First(in, opt)
+		x, ok, err := First(in)
 
 		th.ExpectError(t, err, "err000")
-		th.ExpectValue(t, x, 0)
 		th.ExpectValue(t, ok, false)
-
+		th.ExpectValue(t, x, 0)
 		th.ExpectOpenChan(t, in)
 
-		<-settled
+		time.Sleep(24 * time.Hour) // eventually drained
 
 		th.ExpectDrainedChan(t, in)
 	})
@@ -136,9 +149,9 @@ func TestFirst(t *testing.T) {
 
 		x, ok, err := First(in)
 
-		th.ExpectValue(t, x, 0) // zeroed
-		th.ExpectValue(t, ok, false)
 		th.ExpectError(t, err, "err")
+		th.ExpectValue(t, ok, false)
+		th.ExpectValue(t, x, 0) // zeroed
 	})
 
 	t.Run("unclosed", func(t *testing.T) {
@@ -151,6 +164,37 @@ func TestFirst(t *testing.T) {
 			th.ExpectValue(t, ok, true)
 			th.ExpectValue(t, x, 0)
 		})
+	})
+
+	th.RunSynctest(t, "settlement", func(t *testing.T) {
+		in := FromSlice([]int{}, nil)
+
+		settled, opt := Settlement()
+		x, ok, err := First(in, opt)
+
+		th.ExpectNoError(t, err)
+		th.ExpectValue(t, ok, false)
+		th.ExpectValue(t, x, 0)
+		th.ExpectDrainedChan(t, in)
+
+		<-settled // should not leak
+	})
+
+	th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+		in := FromChan(th.FromRange(0, 20), nil)
+		in = th.DelayEach(in, 1)
+
+		settled, opt := Settlement()
+		x, ok, err := First(in, opt)
+
+		th.ExpectNoError(t, err)
+		th.ExpectValue(t, ok, true)
+		th.ExpectValue(t, x, 0)
+		th.ExpectOpenChan(t, in)
+
+		<-settled
+
+		th.ExpectDrainedChan(t, in)
 	})
 }
 
@@ -180,8 +224,8 @@ func TestForEach(t *testing.T) {
 
 		th.RunSynctest(t, "error in input", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
-			in = th.DelayEach(in, 1)
 			in = replaceWithError(in, 200, fmt.Errorf("err200"))
+			in = th.DelayEach(in, 1)
 
 			var extraCalls atomic.Int64
 			err := ForEach(in, n, func(x int) error {

--- a/consume_test.go
+++ b/consume_test.go
@@ -166,38 +166,15 @@ func TestForEach(t *testing.T) {
 		th.RunSynctest(t, "no errors", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 20), nil)
 
-			settled, opt := Settlement()
-
-			var sum int64
+			var sum atomic.Int64
 			err := ForEach(in, n, func(x int) error {
 				th.SimulateWork(1*time.Second, 2*time.Second)
-				atomic.AddInt64(&sum, int64(x))
-				return nil
-			}, opt)
-
-			th.ExpectNoError(t, err)
-			th.ExpectValue(t, sum, 19*20/2)
-
-			th.ExpectNoRace(sum)
-			th.ExpectDrainedChan(t, in)
-
-			<-settled // should not leak
-		})
-
-		th.RunSynctest(t, "no errors (no settlement)", func(t *testing.T) {
-			in := FromChan(th.FromRange(0, 20), nil)
-
-			var sum int64
-			err := ForEach(in, n, func(x int) error {
-				th.SimulateWork(1*time.Second, 2*time.Second)
-				atomic.AddInt64(&sum, int64(x))
+				sum.Add(int64(x))
 				return nil
 			})
 
 			th.ExpectNoError(t, err)
-			th.ExpectValue(t, sum, 19*20/2)
-
-			th.ExpectNoRace(sum)
+			th.ExpectValue(t, sum.Load(), 19*20/2)
 			th.ExpectDrainedChan(t, in)
 		})
 
@@ -206,89 +183,45 @@ func TestForEach(t *testing.T) {
 			in = th.DelayEach(in, 1)
 			in = replaceWithError(in, 200, fmt.Errorf("err200"))
 
-			settled, opt := Settlement()
-
-			var extraCalls int64 // external side-effect state
+			var extraCalls atomic.Int64
 			err := ForEach(in, n, func(x int) error {
-				atomic.AddInt64(&extraCalls, 1)
+				extraCalls.Add(1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return nil
-			}, opt)
-			atomic.StoreInt64(&extraCalls, 0)
+			})
+			extraCalls.Store(0)
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectOpenChan(t, in)
 
-			<-settled
-			th.ExpectNoRace(extraCalls)
-			th.ExpectDrainedChan(t, in)
+			time.Sleep(24 * time.Hour) // eventually drained
 
-			if n == 1 {
-				th.ExpectValue(t, extraCalls, 0)
-			} else {
-				th.ExpectLTE(t, extraCalls, 50)
-			}
+			th.ExpectLTE(t, int(extraCalls.Load()), when(n == 1, 0, 50))
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "error in func", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = th.DelayEach(in, 1)
 
-			settled, opt := Settlement()
-
-			var extraCalls int64
+			var extraCalls atomic.Int64
 			err := ForEach(in, n, func(x int) error {
-				atomic.AddInt64(&extraCalls, 1)
-				th.SimulateWork(1*time.Second, 2*time.Second)
-				if x == 200 {
-					return fmt.Errorf("err200")
-				}
-				return nil
-			}, opt)
-			atomic.StoreInt64(&extraCalls, 0)
-
-			th.ExpectError(t, err, "err200")
-			th.ExpectOpenChan(t, in)
-
-			<-settled
-			th.ExpectNoRace(extraCalls)
-			th.ExpectDrainedChan(t, in)
-
-			if n == 1 {
-				th.ExpectValue(t, extraCalls, 0)
-			} else {
-				th.ExpectLTE(t, extraCalls, 50)
-			}
-		})
-
-		th.RunSynctest(t, "error in func (no settlement)", func(t *testing.T) {
-			in := FromChan(th.FromRange(0, 1000), nil)
-			in = th.DelayEach(in, 1)
-
-			var extraCalls int64 //nolint:modernize // kept as int64 to mirror the preceding subtest
-			err := ForEach(in, n, func(x int) error {
-				atomic.AddInt64(&extraCalls, 1)
+				extraCalls.Add(1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				if x == 200 {
 					return fmt.Errorf("err200")
 				}
 				return nil
 			})
-			atomic.StoreInt64(&extraCalls, 0)
+			extraCalls.Store(0)
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectOpenChan(t, in)
 
-			time.Sleep(14 * time.Hour) // eventually drained
-			th.ExpectDrainedChan(t, in)
+			time.Sleep(24 * time.Hour) // eventually drained
 
-			// unlike the preceding subtest, here we can't have unprotected access to extraCalls:
-			// it would trigger the race detector w/o the `<-settled` barrier
-			if n == 1 {
-				th.ExpectValue(t, atomic.LoadInt64(&extraCalls), 0)
-			} else {
-				th.ExpectLTE(t, atomic.LoadInt64(&extraCalls), 50)
-			}
+			th.ExpectLTE(t, int(extraCalls.Load()), when(n == 1, 0, 50))
+			th.ExpectDrainedChan(t, in)
 		})
 
 		t.Run("unclosed", func(t *testing.T) {
@@ -303,6 +236,51 @@ func TestForEach(t *testing.T) {
 
 				th.ExpectError(t, err, "err200")
 			})
+		})
+
+		th.RunSynctest(t, "settlement", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 20), nil)
+
+			settled, opt := Settlement()
+
+			var state int64
+			err := ForEach(in, n, func(x int) error {
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				atomic.AddInt64(&state, 1)
+				return nil
+			}, opt)
+
+			th.ExpectNoError(t, err)
+
+			th.ExpectNoRace(state)
+			th.ExpectDrainedChan(t, in)
+
+			<-settled // should not leak
+		})
+
+		th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
+
+			settled, opt := Settlement()
+
+			var state int64
+			err := ForEach(in, n, func(x int) error {
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				if x == 200 {
+					return fmt.Errorf("err200")
+				}
+				atomic.AddInt64(&state, 1)
+				return nil
+			}, opt)
+
+			th.ExpectError(t, err, "err200")
+			th.ExpectOpenChan(t, in)
+
+			<-settled
+
+			th.ExpectNoRace(state)
+			th.ExpectDrainedChan(t, in)
 		})
 
 	})

--- a/consume_test.go
+++ b/consume_test.go
@@ -38,7 +38,7 @@ func TestErr(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
 		in = replaceWithError(in, 10, fmt.Errorf("err010"))
 		in = replaceWithError(in, 15, fmt.Errorf("err015"))
-		in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
+		in = th.DelayEach(in, 1) // needed for inStillOpen assertion
 
 		err := Err(in)
 
@@ -84,7 +84,7 @@ func TestFirst(t *testing.T) {
 	th.RunSynctest(t, "value is first", func(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
 		in = replaceWithError(in, 10, fmt.Errorf("err010"))
-		in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
+		in = th.DelayEach(in, 1) // needed for inStillOpen assertion
 
 		x, ok, err := First(in)
 
@@ -102,7 +102,7 @@ func TestFirst(t *testing.T) {
 	th.RunSynctest(t, "error is first", func(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
 		in = replaceWithError(in, 0, fmt.Errorf("err000"))
-		in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
+		in = th.DelayEach(in, 1) // needed for inStillOpen assertion
 
 		x, ok, err := First(in)
 
@@ -169,11 +169,12 @@ func TestForEach(t *testing.T) {
 			th.ExpectNoRace(sum)
 			th.ExpectDrainedChan(t, in)
 
-			<-settled // asserts that settlement is reported
+			<-settled // should not leak
 		})
 
 		th.RunSynctest(t, "error in input", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
 			in = replaceWithError(in, 200, fmt.Errorf("err200"))
 
 			settled, opt := Settlement()
@@ -187,6 +188,7 @@ func TestForEach(t *testing.T) {
 			atomic.StoreInt64(&extraCalls, 0)
 
 			th.ExpectError(t, err, "err200")
+			th.ExpectOpenChan(t, in)
 
 			<-settled
 			th.ExpectNoRace(extraCalls)
@@ -201,6 +203,7 @@ func TestForEach(t *testing.T) {
 
 		th.RunSynctest(t, "error in func", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
 
 			settled, opt := Settlement()
 
@@ -216,6 +219,7 @@ func TestForEach(t *testing.T) {
 			atomic.StoreInt64(&extraCalls, 0)
 
 			th.ExpectError(t, err, "err200")
+			th.ExpectOpenChan(t, in)
 
 			<-settled
 			th.ExpectNoRace(extraCalls)

--- a/consume_test.go
+++ b/consume_test.go
@@ -356,6 +356,7 @@ func TestAny(t *testing.T) {
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, false)
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "none satisfy", func(t *testing.T) {
@@ -367,11 +368,14 @@ func TestAny(t *testing.T) {
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, false)
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "match is first", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
 
+			// the match at 200 wins over the error at 500
 			res, err := Any(in, n, func(x int) (bool, error) {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				if x == 200 {
@@ -385,14 +389,18 @@ func TestAny(t *testing.T) {
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, true)
+			th.ExpectOpenChan(t, in)
 
-			th.WaitForInflightWork()
+			time.Sleep(24 * time.Hour) // eventually drained
+
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "error is first", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
 
-			// the error at 200 wins over the would-be match at 500
+			// the error at 200 wins over the match at 500
 			res, err := Any(in, n, func(x int) (bool, error) {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				if x == 200 {
@@ -406,14 +414,16 @@ func TestAny(t *testing.T) {
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, res, false)
+			th.ExpectOpenChan(t, in)
 
-			th.WaitForInflightWork()
+			time.Sleep(24 * time.Hour) // eventually drained
+
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "(true,err) tuple", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 			res, err := Any(in, n, func(x int) (bool, error) {
-				th.SimulateWork(1*time.Second, 2*time.Second)
 				if x == 200 {
 					return true, fmt.Errorf("err200")
 				}
@@ -422,8 +432,44 @@ func TestAny(t *testing.T) {
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, res, false)
+		})
 
-			th.WaitForInflightWork()
+		th.RunSynctest(t, "settlement", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 100), nil)
+
+			settled, opt := Settlement()
+			res, err := Any(in, n, func(x int) (bool, error) {
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				return false, nil
+			}, opt)
+
+			th.ExpectNoError(t, err)
+			th.ExpectValue(t, res, false)
+			th.ExpectDrainedChan(t, in)
+
+			<-settled // should not leak
+		})
+
+		th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
+
+			settled, opt := Settlement()
+			res, err := Any(in, n, func(x int) (bool, error) {
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				if x == 200 {
+					return true, nil
+				}
+				return false, nil
+			}, opt)
+
+			th.ExpectNoError(t, err)
+			th.ExpectValue(t, res, true)
+			th.ExpectOpenChan(t, in)
+
+			<-settled
+
+			th.ExpectDrainedChan(t, in)
 		})
 	})
 }
@@ -433,13 +479,16 @@ func TestAll(t *testing.T) {
 	th.TestLevels(t, []int{1, 5}, func(t *testing.T, n int) {
 
 		th.RunSynctest(t, "empty", func(t *testing.T) {
+			in := FromSlice([]int{}, nil)
+
 			// vacuous truth: an empty stream satisfies All
-			res, err := All(FromSlice([]int{}, nil), n, func(int) (bool, error) {
+			res, err := All(in, n, func(int) (bool, error) {
 				return false, nil
 			})
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, true)
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "all satisfy", func(t *testing.T) {
@@ -451,10 +500,12 @@ func TestAll(t *testing.T) {
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, true)
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "counterexample is first", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
 
 			// the counterexample at 200 wins over the error at 500
 			res, err := All(in, n, func(x int) (bool, error) {
@@ -470,12 +521,16 @@ func TestAll(t *testing.T) {
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, false)
+			th.ExpectOpenChan(t, in)
 
-			th.WaitForInflightWork()
+			time.Sleep(24 * time.Hour) // eventually drained
+
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "error is first", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
 
 			// the error at 200 wins over the counterexample at 500
 			res, err := All(in, n, func(x int) (bool, error) {
@@ -491,14 +546,16 @@ func TestAll(t *testing.T) {
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, res, false)
+			th.ExpectOpenChan(t, in)
 
-			th.WaitForInflightWork()
+			time.Sleep(24 * time.Hour) // eventually drained
+
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "(true,err) tuple", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 			res, err := All(in, n, func(x int) (bool, error) {
-				th.SimulateWork(1*time.Second, 2*time.Second)
 				if x == 200 {
 					return true, fmt.Errorf("err200")
 				}
@@ -507,8 +564,44 @@ func TestAll(t *testing.T) {
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, res, false)
+		})
 
-			th.WaitForInflightWork()
+		th.RunSynctest(t, "settlement", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 100), nil)
+
+			settled, opt := Settlement()
+			res, err := All(in, n, func(x int) (bool, error) {
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				return true, nil
+			}, opt)
+
+			th.ExpectNoError(t, err)
+			th.ExpectValue(t, res, true)
+			th.ExpectDrainedChan(t, in)
+
+			<-settled // should not leak
+		})
+
+		th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
+
+			settled, opt := Settlement()
+			res, err := All(in, n, func(x int) (bool, error) {
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				if x == 200 {
+					return false, nil
+				}
+				return true, nil
+			}, opt)
+
+			th.ExpectNoError(t, err)
+			th.ExpectValue(t, res, false)
+			th.ExpectOpenChan(t, in)
+
+			<-settled
+
+			th.ExpectDrainedChan(t, in)
 		})
 	})
 }

--- a/consume_test.go
+++ b/consume_test.go
@@ -18,36 +18,42 @@ func TestErr(t *testing.T) {
 
 	th.RunSynctest(t, "empty", func(t *testing.T) {
 		in := FromSlice([]int{}, nil)
-		err := Err(in)
 
-		th.ExpectDrainedChan(t, in)
+		settled, opt := Settlement()
+		err := Err(in, opt)
 
 		th.ExpectNoError(t, err)
+		th.ExpectDrainedChan(t, in)
+
+		<-settled // should not leak
 	})
 
 	th.RunSynctest(t, "no errors", func(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
-		err := Err(in)
 
-		th.ExpectDrainedChan(t, in)
+		settled, opt := Settlement()
+		err := Err(in, opt)
 
 		th.ExpectNoError(t, err)
+		th.ExpectDrainedChan(t, in)
+
+		<-settled // should not leak
 	})
 
 	th.RunSynctest(t, "error", func(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
 		in = replaceWithError(in, 10, fmt.Errorf("err010"))
 		in = replaceWithError(in, 15, fmt.Errorf("err015"))
-		in = th.DelayEach(in, 1) // needed for inStillOpen assertion
+		in = th.DelayEach(in, 1)
 
-		err := Err(in)
+		settled, opt := Settlement()
+		err := Err(in, opt)
 
 		th.ExpectError(t, err, "err010")
+		th.ExpectOpenChan(t, in)
 
-		_, inStillOpen := <-in
-		th.ExpectValue(t, inStillOpen, true)
+		<-settled
 
-		th.WaitForInflightWork()
 		th.ExpectDrainedChan(t, in)
 	})
 
@@ -73,51 +79,57 @@ func TestFirst(t *testing.T) {
 
 	th.RunSynctest(t, "empty", func(t *testing.T) {
 		in := FromSlice([]int{}, nil)
-		_, ok, err := First(in)
 
-		th.ExpectDrainedChan(t, in)
+		settled, opt := Settlement()
+		_, ok, err := First(in, opt)
 
 		th.ExpectNoError(t, err)
 		th.ExpectValue(t, ok, false)
+
+		th.ExpectDrainedChan(t, in)
+
+		<-settled // should not leak
 	})
 
 	th.RunSynctest(t, "value is first", func(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
 		in = replaceWithError(in, 10, fmt.Errorf("err010"))
-		in = th.DelayEach(in, 1) // needed for inStillOpen assertion
+		in = th.DelayEach(in, 1)
 
-		x, ok, err := First(in)
+		settled, opt := Settlement()
+		x, ok, err := First(in, opt)
 
 		th.ExpectNoError(t, err)
 		th.ExpectValue(t, ok, true)
 		th.ExpectValue(t, x, 0)
 
-		_, inStillOpen := <-in
-		th.ExpectValue(t, inStillOpen, true)
+		th.ExpectOpenChan(t, in)
 
-		th.WaitForInflightWork()
+		<-settled
+
 		th.ExpectDrainedChan(t, in)
 	})
 
 	th.RunSynctest(t, "error is first", func(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
 		in = replaceWithError(in, 0, fmt.Errorf("err000"))
-		in = th.DelayEach(in, 1) // needed for inStillOpen assertion
+		in = th.DelayEach(in, 1)
 
-		x, ok, err := First(in)
+		settled, opt := Settlement()
+		x, ok, err := First(in, opt)
 
 		th.ExpectError(t, err, "err000")
 		th.ExpectValue(t, x, 0)
 		th.ExpectValue(t, ok, false)
 
-		_, inStillOpen := <-in
-		th.ExpectValue(t, inStillOpen, true)
+		th.ExpectOpenChan(t, in)
 
-		th.WaitForInflightWork()
+		<-settled
+
 		th.ExpectDrainedChan(t, in)
 	})
 
-	t.Run("value alongside error", func(t *testing.T) {
+	th.RunSynctest(t, "value alongside error", func(t *testing.T) {
 		in := make(chan Try[int], 1)
 		in <- Try[int]{Value: 10, Error: fmt.Errorf("err")}
 		close(in)

--- a/consume_test.go
+++ b/consume_test.go
@@ -154,75 +154,77 @@ func TestForEach(t *testing.T) {
 		th.RunSynctest(t, "no errors", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 20), nil)
 
-			var sum atomic.Int64
+			settled, opt := Settlement()
+
+			var sum int64
 			err := ForEach(in, n, func(x int) error {
 				th.SimulateWork(1*time.Second, 2*time.Second)
-
-				sum.Add(int64(x))
+				atomic.AddInt64(&sum, int64(x))
 				return nil
-			})
-
-			th.ExpectDrainedChan(t, in)
+			}, opt)
 
 			th.ExpectNoError(t, err)
-			th.ExpectValue(t, sum.Load(), int64(19*20/2))
+			th.ExpectValue(t, sum, 19*20/2)
+
+			th.ExpectNoRace(sum)
+			th.ExpectDrainedChan(t, in)
+
+			<-settled // asserts that settlement is reported
 		})
 
 		th.RunSynctest(t, "error in input", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = replaceWithError(in, 200, fmt.Errorf("err200"))
-			in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
 
-			var extraCalls atomic.Int64
+			settled, opt := Settlement()
+
+			var extraCalls int64 // external side-effect state
 			err := ForEach(in, n, func(x int) error {
-				extraCalls.Add(1)
+				atomic.AddInt64(&extraCalls, 1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return nil
-			})
-			extraCalls.Store(0)
+			}, opt)
+			atomic.StoreInt64(&extraCalls, 0)
 
 			th.ExpectError(t, err, "err200")
 
-			_, inStillOpen := <-in
-			th.ExpectValue(t, inStillOpen, true)
-
-			th.WaitForInflightWork()
+			<-settled
+			th.ExpectNoRace(extraCalls)
 			th.ExpectDrainedChan(t, in)
 
 			if n == 1 {
-				th.ExpectValue(t, extraCalls.Load(), 0)
+				th.ExpectValue(t, extraCalls, 0)
 			} else {
-				th.ExpectBetween(t, extraCalls.Load(), 0, 50)
+				th.ExpectLTE(t, extraCalls, 50)
 			}
 		})
 
 		th.RunSynctest(t, "error in func", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
-			in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
 
-			var extraCalls atomic.Int64
+			settled, opt := Settlement()
+
+			var extraCalls int64
 			err := ForEach(in, n, func(x int) error {
-				extraCalls.Add(1)
+				atomic.AddInt64(&extraCalls, 1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				if x == 200 {
 					return fmt.Errorf("err200")
 				}
 				return nil
-			})
-			extraCalls.Store(0)
+			}, opt)
+			atomic.StoreInt64(&extraCalls, 0)
 
 			th.ExpectError(t, err, "err200")
 
-			_, inStillOpen := <-in
-			th.ExpectValue(t, inStillOpen, true)
-
-			th.WaitForInflightWork()
+			<-settled
+			th.ExpectNoRace(extraCalls)
 			th.ExpectDrainedChan(t, in)
 
 			if n == 1 {
-				th.ExpectValue(t, extraCalls.Load(), 0)
+				th.ExpectValue(t, extraCalls, 0)
 			} else {
-				th.ExpectBetween(t, extraCalls.Load(), 0, 50)
+				th.ExpectLTE(t, extraCalls, 50)
 			}
 		})
 

--- a/consume_test.go
+++ b/consume_test.go
@@ -172,6 +172,23 @@ func TestForEach(t *testing.T) {
 			<-settled // should not leak
 		})
 
+		th.RunSynctest(t, "no errors (no settlement)", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 20), nil)
+
+			var sum int64
+			err := ForEach(in, n, func(x int) error {
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				atomic.AddInt64(&sum, int64(x))
+				return nil
+			})
+
+			th.ExpectNoError(t, err)
+			th.ExpectValue(t, sum, 19*20/2)
+
+			th.ExpectNoRace(sum)
+			th.ExpectDrainedChan(t, in)
+		})
+
 		th.RunSynctest(t, "error in input", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = th.DelayEach(in, 1)
@@ -229,6 +246,36 @@ func TestForEach(t *testing.T) {
 				th.ExpectValue(t, extraCalls, 0)
 			} else {
 				th.ExpectLTE(t, extraCalls, 50)
+			}
+		})
+
+		th.RunSynctest(t, "error in func (no settlement)", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
+
+			var extraCalls int64 //nolint:modernize // kept as int64 to mirror the preceding subtest
+			err := ForEach(in, n, func(x int) error {
+				atomic.AddInt64(&extraCalls, 1)
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				if x == 200 {
+					return fmt.Errorf("err200")
+				}
+				return nil
+			})
+			atomic.StoreInt64(&extraCalls, 0)
+
+			th.ExpectError(t, err, "err200")
+			th.ExpectOpenChan(t, in)
+
+			time.Sleep(14 * time.Hour) // eventually drained
+			th.ExpectDrainedChan(t, in)
+
+			// unlike the preceding subtest, here we can't have unprotected access to extraCalls:
+			// it would trigger the race detector w/o the `<-settled` barrier
+			if n == 1 {
+				th.ExpectValue(t, atomic.LoadInt64(&extraCalls), 0)
+			} else {
+				th.ExpectLTE(t, atomic.LoadInt64(&extraCalls), 50)
 			}
 		})
 

--- a/example_test.go
+++ b/example_test.go
@@ -692,6 +692,55 @@ func ExampleReduce() {
 	fmt.Println("Error:", err)
 }
 
+// This example demonstrates how to wait until the pipeline has no callbacks left to run.
+// [ForEach] returns as soon as the error is known, while the source and the remaining
+// workers are still going. Settlement reports when all of them have stopped.
+func ExampleSettlement() {
+	// Canceling this context stops the source and all in-flight work
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Use Generate instead of FromSlice to make the source context-aware
+	// and infinite
+	ids := rill.Generate(func(send func(int), sendError func(error)) {
+		for i := 1; ctx.Err() == nil; i++ {
+			send(i)
+		}
+	})
+
+	// Callbacks write here, so it's unsafe to touch while any of them is still running
+	var mu sync.Mutex
+	var seen []int
+
+	settled, opt := rill.Settlement()
+
+	// Process ids until one of them turns out to be bad
+	// Concurrency = 3
+	err := rill.ForEach(ids, 3, func(id int) error {
+		simulateWork(500 * time.Millisecond)
+
+		mu.Lock()
+		seen = append(seen, id)
+		mu.Unlock()
+
+		fmt.Println("Seen:", id)
+
+		if id == 15 {
+			return fmt.Errorf("bad id (%d)", id)
+		}
+
+		return nil
+	}, opt)
+	fmt.Println("* Returned:", err)
+
+	cancel()  // stop the source and the callbacks that are still running
+	<-settled // wait until none of them can touch seen anymore
+	fmt.Println("* Settled")
+
+	// No callback can be running now, so this needs no mutex
+	fmt.Println("Total seen:", len(seen))
+}
+
 func ExampleTee() {
 	// Convert a slice of numbers into a stream
 	numbers := rill.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -97,3 +97,11 @@ func replaceWithError[A comparable](in <-chan Try[A], value A, err error) <-chan
 
 	return out
 }
+
+// ternary operator to keep tests concise
+func when[A any](cond bool, trueVal A, falseVal A) A {
+	if cond {
+		return trueVal
+	}
+	return falseVal
+}

--- a/internal/core/util.go
+++ b/internal/core/util.go
@@ -5,24 +5,6 @@ func Drain[A any](in <-chan A) {
 	}
 }
 
-func Discard[A any](in <-chan A) {
-	if in == nil {
-		return
-	}
-
-	// do nothing if the channel is already closed
-	select {
-	case _, ok := <-in:
-		if !ok {
-			return
-		}
-	default:
-	}
-
-	// drain in background
-	go Drain(in)
-}
-
 func Buffer[A any](in <-chan A, size int) <-chan A {
 	if in == nil {
 		return nil

--- a/internal/core/util_test.go
+++ b/internal/core/util_test.go
@@ -15,29 +15,6 @@ func TestDrain(t *testing.T) {
 	})
 }
 
-func TestDiscard(t *testing.T) {
-	th.RunSynctest(t, "nil", func(t *testing.T) {
-		Discard[int](nil) // leak would be caught by the bubble
-	})
-
-	th.RunSynctest(t, "normal", func(t *testing.T) {
-		in := make(chan int)
-		Discard(in) // doesn't block
-
-		// able to write
-		in <- 1
-		in <- 2
-		close(in)
-	})
-
-	th.RunSynctest(t, "closed", func(t *testing.T) {
-		in := make(chan int)
-		close(in)
-		Discard(in)
-		th.ExpectDrainedChan(t, in)
-	})
-}
-
 func TestBuffer(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		th.ExpectValue(t, Buffer[string](nil, 2), nil)

--- a/internal/th/assertions.go
+++ b/internal/th/assertions.go
@@ -132,6 +132,16 @@ func ExpectDrainedChan[A any](t *testing.T, ch <-chan A) {
 	}
 }
 
+// ExpectOpenChan consumes one item from the channel and asserts that the
+// channel was open. It blocks until an item arrives or the channel is closed.
+func ExpectOpenChan[A any](t *testing.T, ch <-chan A) {
+	t.Helper()
+	_, isOpen := <-ch
+	if !isOpen {
+		t.Errorf("expected channel to be open, but it's closed")
+	}
+}
+
 // ExpectBlock runs f in a synctest bubble and asserts that the main goroutine
 // is durably blocked.
 func ExpectBlock(t *testing.T, f func(t *testing.T)) {

--- a/internal/th/assertions.go
+++ b/internal/th/assertions.go
@@ -25,13 +25,6 @@ func ExpectLTE[A cmp.Ordered](t *testing.T, actual A, max A) {
 	}
 }
 
-func ExpectTrue(t *testing.T, actual bool) {
-	t.Helper()
-	if !actual {
-		t.Errorf("expected true, got false")
-	}
-}
-
 func ExpectSlice[A comparable](t *testing.T, actual []A, expected []A) {
 	t.Helper()
 	if len(expected) != len(actual) {

--- a/internal/th/assertions.go
+++ b/internal/th/assertions.go
@@ -25,13 +25,6 @@ func ExpectLTE[A cmp.Ordered](t *testing.T, actual A, max A) {
 	}
 }
 
-func ExpectBetween[A cmp.Ordered](t *testing.T, actual A, min A, max A) {
-	t.Helper()
-	if actual < min || actual > max {
-		t.Errorf("expected %v to be between %v and %v", actual, min, max)
-	}
-}
-
 func ExpectTrue(t *testing.T, actual bool) {
 	t.Helper()
 	if !actual {

--- a/internal/th/assertions.go
+++ b/internal/th/assertions.go
@@ -18,10 +18,24 @@ func ExpectValue[A comparable](t *testing.T, actual A, expected A) {
 	}
 }
 
+func ExpectLTE[A cmp.Ordered](t *testing.T, actual A, max A) {
+	t.Helper()
+	if actual > max {
+		t.Errorf("expected %v to be less than or equal to %v", actual, max)
+	}
+}
+
 func ExpectBetween[A cmp.Ordered](t *testing.T, actual A, min A, max A) {
 	t.Helper()
 	if actual < min || actual > max {
 		t.Errorf("expected %v to be between %v and %v", actual, min, max)
+	}
+}
+
+func ExpectTrue(t *testing.T, actual bool) {
+	t.Helper()
+	if !actual {
+		t.Errorf("expected true, got false")
 	}
 }
 

--- a/internal/th/helpers.go
+++ b/internal/th/helpers.go
@@ -67,7 +67,8 @@ func ExpectNoRace[T any](value T) {
 // DelayEach forwards items, sleeping for the given duration before each one.
 // Under synctest this makes it impossible to consume the channel in zero fake
 // time, hence one goroutine (main) can observe the intermediate state of another
-// goroutine (drain) consuming the stream.
+// goroutine (drain) consuming the stream. This function is usually
+// paired with [ExpectOpenChan].
 //
 // A sleep of 1ns - written as a bare 1 in the tests - is the minimum that
 // gives observability: the sleep completes only when every goroutine in the

--- a/internal/th/helpers.go
+++ b/internal/th/helpers.go
@@ -65,10 +65,14 @@ func ExpectNoRace[T any](value T) {
 }
 
 // DelayEach forwards items, sleeping for the given duration before each one.
-// Useful to make a stream slow. Under synctest even a minimal 1ns delay acts
-// as a freeze point: the stream cannot advance past this stage while any
-// goroutine in the bubble is runnable, because fake time only advances when
-// all goroutines are durably blocked.
+// Under synctest this makes it impossible to consume the channel in zero fake
+// time, hence one goroutine (main) can observe the intermediate state of another
+// goroutine (drain) consuming the stream.
+//
+// A sleep of 1ns - written as a bare 1 in the tests - is the minimum that
+// gives observability: the sleep completes only when every goroutine in the
+// bubble is durably blocked, so the stream cannot advance while any goroutine
+// is runnable.
 func DelayEach[A any](in <-chan A, delay time.Duration) <-chan A {
 	out := make(chan A)
 	go func() {

--- a/internal/th/helpers.go
+++ b/internal/th/helpers.go
@@ -104,14 +104,6 @@ func SimulateWork(min, max time.Duration) {
 	time.Sleep(d)
 }
 
-// WaitForInflightWork is just a sleep with a semantic name.
-// It fast-forwards fake time far enough that any goroutines currently
-// simulating work have a chance to complete.
-// Mostly used with early-exit tests.
-func WaitForInflightWork() {
-	time.Sleep(1 * time.Hour)
-}
-
 func DoConcurrently(ff ...func()) {
 	var wg sync.WaitGroup
 

--- a/internal/th/helpers.go
+++ b/internal/th/helpers.go
@@ -46,6 +46,24 @@ func DontClose[A any](in <-chan A) <-chan A {
 	return out
 }
 
+// ExpectNoRace is a semantic name for a bare unsynchronized read.
+// Tests sometimes need to do an unsynchronized access to a variable, to
+// have the race detector confirm that all writes in other goroutines
+// happen before this read. It's enough to do a no-op read:
+//
+//	_ = myVariable
+//
+// This works, but requires an explaining comment at every site.
+// ExpectNoRace is also a no-op, but makes the call site clearer:
+//
+//	th.ExpectNoRace(myVariable)
+//
+//go:noinline
+func ExpectNoRace[T any](value T) {
+	// This function does nothing and has a noinline pragma to make sure
+	// the compiler does not remove the variable access.
+}
+
 // DelayEach forwards items, sleeping for the given duration before each one.
 // Useful to make a stream slow. Under synctest even a minimal 1ns delay acts
 // as a freeze point: the stream cannot advance past this stage while any

--- a/iter.go
+++ b/iter.go
@@ -54,8 +54,8 @@ func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
 // If the caller stops iteration early using break or return, ToSeq2 drains the
 // remaining input in the background, like blocking functions such as [ForEach].
 //
-// The returned iterator must be ranged over, even if the loop breaks on the
-// first item. Otherwise the input is never drained.
+// The returned iterator is single-use. If it is never ranged, the input is
+// never drained.
 func ToSeq2[A any](in <-chan Try[A], options ...SinkOption) iter.Seq2[A, error] {
 	var once sync.Once
 

--- a/iter.go
+++ b/iter.go
@@ -2,6 +2,7 @@ package rill
 
 import (
 	"iter"
+	"sync"
 )
 
 // FromSeq converts an iterator into a stream.
@@ -52,9 +53,15 @@ func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
 //
 // If the caller stops iteration early using break or return, ToSeq2 drains the
 // remaining input in the background, like blocking functions such as [ForEach].
-func ToSeq2[A any](in <-chan Try[A]) iter.Seq2[A, error] {
+//
+// The returned iterator must be ranged over, even if the loop breaks on the
+// first item. Otherwise the input is never drained.
+func ToSeq2[A any](in <-chan Try[A], options ...SinkOption) iter.Seq2[A, error] {
+	var once sync.Once
+
 	return func(yield func(A, error) bool) {
-		defer Discard(in)
+		defer once.Do(func() { Discard(in, options...) })
+
 		for x := range in {
 			if !yield(x.Value, x.Error) {
 				return

--- a/iter_test.go
+++ b/iter_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"testing"
-	"testing/synctest"
 
 	"github.com/destel/rill/internal/th"
 )
@@ -23,7 +22,8 @@ func TestToSeq2(t *testing.T) {
 		in = replaceWithError(in, 5, fmt.Errorf("err5"))
 		in = replaceWithError(in, 8, fmt.Errorf("err8"))
 
-		out := ToSeq2(in)
+		settled, opt := Settlement()
+		out := ToSeq2(in, opt)
 
 		var outSlice []Item[int]
 		for val, err := range out {
@@ -34,7 +34,6 @@ func TestToSeq2(t *testing.T) {
 			outSlice = appendVal(outSlice, val)
 		}
 
-		synctest.Wait()
 		th.ExpectDrainedChan(t, in)
 
 		var expectedSlice []Item[int]
@@ -45,13 +44,17 @@ func TestToSeq2(t *testing.T) {
 		expectedSlice = appendVal(expectedSlice, 9)
 
 		th.ExpectSlice(t, outSlice, expectedSlice)
+
+		<-settled // asserts that settlement is reported
 	})
 
 	th.RunSynctest(t, "early exit", func(t *testing.T) {
 		in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)
+		in = th.DelayEach(in, 1)
 		in = replaceWithError(in, 8, fmt.Errorf("err8"))
 
-		out := ToSeq2(in)
+		settled, opt := Settlement()
+		out := ToSeq2(in, opt)
 
 		var outSlice []Item[int]
 		for val, err := range out {
@@ -66,13 +69,14 @@ func TestToSeq2(t *testing.T) {
 			outSlice = appendVal(outSlice, val)
 		}
 
-		synctest.Wait()
-		th.ExpectDrainedChan(t, in)
-
 		var expectedSlice []Item[int]
 		expectedSlice = appendVal(expectedSlice, 0, 1, 2, 3, 4)
 
 		th.ExpectSlice(t, outSlice, expectedSlice)
+		th.ExpectOpenChan(t, in)
+
+		<-settled
+		th.ExpectDrainedChan(t, in)
 	})
 
 	t.Run("unclosed", func(t *testing.T) {
@@ -84,6 +88,32 @@ func TestToSeq2(t *testing.T) {
 			for range out {
 				break // early return immediately
 			}
+		})
+	})
+
+	th.RunSynctest(t, "double consumption does not panic", func(t *testing.T) {
+		in := FromChan(th.FromRange(0, 20), nil)
+
+		settled, opt := Settlement()
+		out := ToSeq2(in, opt)
+
+		for range out {
+		}
+		for range out {
+		}
+
+		<-settled // asserts that settlement is reported
+		th.ExpectDrainedChan(t, in)
+	})
+
+	t.Run("never ranged", func(t *testing.T) {
+		th.ExpectBlock(t, func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 20), nil)
+
+			settled, opt := Settlement()
+			_ = ToSeq2(in, opt)
+
+			<-settled // blocks forever
 		})
 	})
 }

--- a/iter_test.go
+++ b/iter_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/destel/rill/internal/th"
 )
@@ -22,8 +23,7 @@ func TestToSeq2(t *testing.T) {
 		in = replaceWithError(in, 5, fmt.Errorf("err5"))
 		in = replaceWithError(in, 8, fmt.Errorf("err8"))
 
-		settled, opt := Settlement()
-		out := ToSeq2(in, opt)
+		out := ToSeq2(in)
 
 		var outSlice []Item[int]
 		for val, err := range out {
@@ -44,17 +44,14 @@ func TestToSeq2(t *testing.T) {
 		expectedSlice = appendVal(expectedSlice, 9)
 
 		th.ExpectSlice(t, outSlice, expectedSlice)
-
-		<-settled // asserts that settlement is reported
 	})
 
 	th.RunSynctest(t, "early exit", func(t *testing.T) {
 		in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)
-		in = th.DelayEach(in, 1)
 		in = replaceWithError(in, 8, fmt.Errorf("err8"))
+		in = th.DelayEach(in, 1)
 
-		settled, opt := Settlement()
-		out := ToSeq2(in, opt)
+		out := ToSeq2(in)
 
 		var outSlice []Item[int]
 		for val, err := range out {
@@ -75,8 +72,21 @@ func TestToSeq2(t *testing.T) {
 		th.ExpectSlice(t, outSlice, expectedSlice)
 		th.ExpectOpenChan(t, in)
 
-		<-settled
+		time.Sleep(24 * time.Hour) // eventually drained
+
 		th.ExpectDrainedChan(t, in)
+	})
+
+	t.Run("never ranged", func(t *testing.T) {
+		th.ExpectLeak(t, func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 20), nil)
+
+			_ = ToSeq2(in)
+
+			time.Sleep(24 * time.Hour) // not drained even eventually
+
+			th.ExpectOpenChan(t, in)
+		})
 	})
 
 	t.Run("unclosed", func(t *testing.T) {
@@ -91,7 +101,47 @@ func TestToSeq2(t *testing.T) {
 		})
 	})
 
-	th.RunSynctest(t, "double consumption does not panic", func(t *testing.T) {
+	th.RunSynctest(t, "settlement", func(t *testing.T) {
+		in := FromChan(th.FromRange(0, 10), nil)
+
+		settled, opt := Settlement()
+		out := ToSeq2(in, opt)
+
+		var outSlice []int
+		for val, _ := range out {
+			outSlice = append(outSlice, val)
+		}
+
+		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+		th.ExpectDrainedChan(t, in)
+
+		<-settled // should not leak
+	})
+
+	th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+		in := FromChan(th.FromRange(0, 10), nil)
+		in = th.DelayEach(in, 1)
+
+		settled, opt := Settlement()
+		out := ToSeq2(in, opt)
+
+		var outSlice []int
+		for val, _ := range out {
+			if val == 5 {
+				break
+			}
+			outSlice = append(outSlice, val)
+		}
+
+		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4})
+		th.ExpectOpenChan(t, in)
+
+		<-settled
+
+		th.ExpectDrainedChan(t, in)
+	})
+
+	th.RunSynctest(t, "settlement (double consumption does not panic)", func(t *testing.T) {
 		in := FromChan(th.FromRange(0, 20), nil)
 
 		settled, opt := Settlement()
@@ -104,17 +154,6 @@ func TestToSeq2(t *testing.T) {
 
 		<-settled // asserts that settlement is reported
 		th.ExpectDrainedChan(t, in)
-	})
-
-	t.Run("never ranged", func(t *testing.T) {
-		th.ExpectBlock(t, func(t *testing.T) {
-			in := FromChan(th.FromRange(0, 20), nil)
-
-			settled, opt := Settlement()
-			_ = ToSeq2(in, opt)
-
-			<-settled // blocks forever
-		})
 	})
 }
 

--- a/iter_test.go
+++ b/iter_test.go
@@ -108,7 +108,7 @@ func TestToSeq2(t *testing.T) {
 		out := ToSeq2(in, opt)
 
 		var outSlice []int
-		for val, _ := range out {
+		for val := range out {
 			outSlice = append(outSlice, val)
 		}
 
@@ -126,7 +126,7 @@ func TestToSeq2(t *testing.T) {
 		out := ToSeq2(in, opt)
 
 		var outSlice []int
-		for val, _ := range out {
+		for val := range out {
 			if val == 5 {
 				break
 			}

--- a/options.go
+++ b/options.go
@@ -28,6 +28,9 @@ func (f sinkOptionFunc) apply(options *sinkOptions) {
 func collectSinkOptions(options []SinkOption) sinkOptions {
 	var result sinkOptions
 	for _, option := range options {
+		if option == nil {
+			continue
+		}
 		option.apply(&result)
 	}
 	return result

--- a/options.go
+++ b/options.go
@@ -1,0 +1,55 @@
+package rill
+
+import "sync/atomic"
+
+type sinkOptions struct {
+	settleChan chan struct{}
+}
+
+// A SinkOption is an optional argument accepted by every sink, such as the
+// one returned by [Settlement]. The interface cannot be implemented outside
+// this package.
+type SinkOption interface {
+	apply(options *sinkOptions)
+}
+
+type sinkOptionFunc func(options *sinkOptions)
+
+func (f sinkOptionFunc) apply(options *sinkOptions) {
+	f(options)
+}
+
+func collectSinkOptions(options []SinkOption) sinkOptions {
+	var result sinkOptions
+	for _, option := range options {
+		option.apply(&result)
+	}
+	return result
+}
+
+// Settlement reports when the pipeline has no callbacks left to run. It
+// returns the signal channel and the option that enables it. The option
+// must not be reused across sinks.
+//
+// A pipeline settles when every callback started by the sink and its
+// upstream stages has returned, including the ones that kept running
+// after the result was known. No callback runs after that.
+//
+// Settlement does not stop the pipeline: unless the source is stopped
+// first, the channel is closed only after the entire input is consumed.
+// With an infinite source, that never happens.
+func Settlement() (settled <-chan struct{}, opt SinkOption) {
+	ch := make(chan struct{})
+	settled = ch
+
+	var cnt atomic.Int32
+
+	opt = sinkOptionFunc(func(options *sinkOptions) {
+		if cnt.Add(1) > 1 {
+			panic("rill: settlement option must not be reused across sinks")
+		}
+
+		options.settleChan = ch
+	})
+	return
+}

--- a/options.go
+++ b/options.go
@@ -52,7 +52,7 @@ func Settlement() (settled <-chan struct{}, opt SinkOption) {
 
 	opt = sinkOptionFunc(func(options *sinkOptions) {
 		if cnt.Add(1) > 1 {
-			panic("rill: settlement option must not be reused across sinks")
+			panic("rill: the same settlement option used more than once")
 		}
 
 		options.settleChans = append(options.settleChans, ch)

--- a/options.go
+++ b/options.go
@@ -3,7 +3,13 @@ package rill
 import "sync/atomic"
 
 type sinkOptions struct {
-	settleChan chan struct{}
+	settleChans []chan struct{}
+}
+
+func (o sinkOptions) settle() {
+	for _, ch := range o.settleChans {
+		close(ch)
+	}
 }
 
 // A SinkOption is an optional argument accepted by every sink, such as the
@@ -49,7 +55,7 @@ func Settlement() (settled <-chan struct{}, opt SinkOption) {
 			panic("rill: settlement option must not be reused across sinks")
 		}
 
-		options.settleChan = ch
+		options.settleChans = append(options.settleChans, ch)
 	})
 	return
 }

--- a/options.go
+++ b/options.go
@@ -54,6 +54,10 @@ func Settlement() (settled <-chan struct{}, opt SinkOption) {
 	var cnt atomic.Int32
 
 	opt = sinkOptionFunc(func(options *sinkOptions) {
+		// This fires when the options are opened, i.e. at sink return rather
+		// than at the call site. Detecting reuse at sink entry would require
+		// re-plumbing every sink chain - too costly in the current architecture
+		// for what it buys.
 		if cnt.Add(1) > 1 {
 			panic("rill: the same settlement option used more than once")
 		}

--- a/options_test.go
+++ b/options_test.go
@@ -6,11 +6,24 @@ import (
 	"github.com/destel/rill/internal/th"
 )
 
-func TestCollectSinkOptions(t *testing.T) {
+func TestSinkOption(t *testing.T) {
 	t.Run("nil options are ignored", func(t *testing.T) {
 		_, opt := Settlement()
 
 		opts := collectSinkOptions([]SinkOption{nil, opt, nil})
 		th.ExpectValue(t, len(opts.settleChans), 1)
+	})
+
+	t.Run("settlement can't be reused", func(t *testing.T) {
+		_, opt := Settlement()
+		_, _, _ = First(FromSlice([]int{}, nil), opt)
+
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected panic")
+			}
+		}()
+
+		_, _, _ = First(FromSlice([]int{}, nil), opt)
 	})
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,16 @@
+package rill
+
+import (
+	"testing"
+
+	"github.com/destel/rill/internal/th"
+)
+
+func TestCollectSinkOptions(t *testing.T) {
+	t.Run("nil options are ignored", func(t *testing.T) {
+		_, opt := Settlement()
+
+		opts := collectSinkOptions([]SinkOption{nil, opt, nil})
+		th.ExpectValue(t, len(opts.settleChans), 1)
+	})
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,0 +1,98 @@
+package rill
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/destel/rill/internal/th"
+)
+
+func isPalindrome(s string) bool {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		if s[i] != s[j] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPipelines(t *testing.T) {
+
+	// Count the palindromes among the first 10000 numbers,
+	// grouped by digit count.
+	th.RunSynctest(t, "basic", func(t *testing.T) {
+		numbers := Generate(func(send func(int), sendError func(error)) {
+			for i := range 10000 {
+				send(i)
+			}
+		})
+
+		strs := Map(numbers, 10, func(x int) (string, error) {
+			return strconv.Itoa(x), nil
+		})
+
+		palindromes := Filter(strs, 10, func(x string) (bool, error) {
+			return isPalindrome(x), nil
+		})
+
+		counts, err := MapReduce(palindromes,
+			2, func(s string) (int, int, error) {
+				return len(s), 1, nil
+			},
+			10, func(x, y int) (int, error) {
+				return x + y, nil
+			},
+		)
+
+		th.ExpectNoError(t, err)
+		th.ExpectMap(t, counts, map[int]int{
+			1: 10,
+			2: 9,
+			3: 90,
+			4: 90,
+		})
+	})
+
+	// Find the first palindromic number greater than 123456.
+	th.RunSynctest(t, "settlement", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// shared state, mutated with atomics by the stages
+		var totalCalls int64
+
+		// an infinite source: generates numbers until the context is canceled
+		numbers := Generate(func(send func(int), sendError func(error)) {
+			for i := 123456; ctx.Err() == nil; i++ {
+				send(i)
+			}
+		})
+
+		strs := OrderedMap(numbers, 10, func(x int) (string, error) {
+			atomic.AddInt64(&totalCalls, 1)
+			return strconv.Itoa(x), nil
+		})
+
+		palindromes := OrderedFilter(strs, 10, func(x string) (bool, error) {
+			atomic.AddInt64(&totalCalls, 1)
+			return isPalindrome(x), nil
+		})
+
+		settled, opt := Settlement()
+		res, _, err := First(palindromes, opt)
+
+		// stop the source from generating more numbers
+		cancel()
+
+		th.ExpectNoError(t, err)
+		th.ExpectValue(t, res, "124421")
+
+		// wait for the pipeline to settle (no more callbacks)
+		<-settled
+
+		// shared state is now safe to read without atomics
+		th.ExpectNoRace(totalCalls)
+	})
+}

--- a/reduce.go
+++ b/reduce.go
@@ -261,7 +261,7 @@ func Reduce[A any](in <-chan Try[A], n int, f func(A, A) (A, error), options ...
 // for the mapper and reducer functions respectively.
 //
 // See the package documentation for more information on blocking functions and error handling.
-func MapReduce[A any, K comparable, V any](in <-chan Try[A], nm int, mapper func(A) (K, V, error), nr int, reducer func(V, V) (V, error)) (map[K]V, error) {
+func MapReduce[A any, K comparable, V any](in <-chan Try[A], nm int, mapper func(A) (K, V, error), nr int, reducer func(V, V) (V, error), options ...SinkOption) (map[K]V, error) {
 	validateN(nm)
 	validateNilFunc(mapper == nil)
 	validateN(nr)
@@ -287,7 +287,7 @@ func MapReduce[A any, K comparable, V any](in <-chan Try[A], nm int, mapper func
 			}
 			acc[k] = merged
 			return nil
-		})
+		}, options...)
 
 		if err != nil {
 			return nil, err
@@ -448,7 +448,8 @@ func MapReduce[A any, K comparable, V any](in <-chan Try[A], nm int, mapper func
 		}
 	}
 
-	defer Discard(entries)
+	inputDrained, opt := Settlement()
+	defer Discard(entries, opt)
 
 	// Start the workers
 	var wg sync.WaitGroup
@@ -460,19 +461,28 @@ func MapReduce[A any, K comparable, V any](in <-chan Try[A], nm int, mapper func
 	go func() {
 		wg.Wait()
 
-		if !errSeen.Load() {
-			// By construction, each list has converged to exactly one node
-			res := make(map[K]V, len(lists))
-			for k, l := range lists {
-				res[k] = l.Front().Value.value
-			}
-			out <- Try[map[K]V]{Value: res}
+		// The out channel propagates both the result and the settlement signal to First.
+		// We're only allowed to close it after the input is drained.
+
+		// Error path: items can remain in the input, so we wait for the drain
+		if errSeen.Load() {
+			<-inputDrained
+			close(out)
+			return
 		}
 
+		// Happy path: the workers exhausted the input, so there is nothing to
+		// drain. By construction, each map entry has converged to exactly one node.
+		res := make(map[K]V, len(lists))
+		for k, l := range lists {
+			res[k] = l.Front().Value.value
+		}
+
+		out <- Try[map[K]V]{Value: res}
 		close(out)
 	}()
 
-	res, _, err := First(out)
+	res, _, err := First(out, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/reduce.go
+++ b/reduce.go
@@ -22,7 +22,7 @@ import (
 // Reduce is a blocking function that processes items concurrently using n goroutines.
 //
 // See the package documentation for more information on blocking functions and error handling.
-func Reduce[A any](in <-chan Try[A], n int, f func(A, A) (A, error)) (result A, hasResult bool, err error) {
+func Reduce[A any](in <-chan Try[A], n int, f func(A, A) (A, error), options ...SinkOption) (result A, hasResult bool, err error) {
 	validateN(n)
 	validateNilFunc(f == nil)
 
@@ -42,7 +42,8 @@ func Reduce[A any](in <-chan Try[A], n int, f func(A, A) (A, error)) (result A, 
 			}
 			acc = res
 			return nil
-		})
+		}, options...)
+
 		if err != nil {
 			var zero A
 			return zero, false, err
@@ -210,7 +211,8 @@ func Reduce[A any](in <-chan Try[A], n int, f func(A, A) (A, error)) (result A, 
 		}
 	}
 
-	defer Discard(in)
+	inputDrained, opt := Settlement()
+	defer Discard(in, opt)
 
 	// Start the workers
 	var wg sync.WaitGroup
@@ -222,17 +224,26 @@ func Reduce[A any](in <-chan Try[A], n int, f func(A, A) (A, error)) (result A, 
 	go func() {
 		wg.Wait()
 
-		if !errSeen.Load() {
-			// By construction, the list contains 0 or 1 nodes
-			if first := nodes.Front(); first != nil {
-				out <- Try[A]{Value: first.Value.value}
-			}
+		// The out channel propagates both the result and the settlement signal to First.
+		// We're only allowed to close it after the input is drained.
+
+		// Error path: items can remain in the input, so we wait for the drain
+		if errSeen.Load() {
+			<-inputDrained
+			close(out)
+			return
+		}
+
+		// Happy path: the workers exhausted the input, so there is nothing to
+		// drain. By construction, the list contains 0 or 1 nodes.
+		if first := nodes.Front(); first != nil {
+			out <- Try[A]{Value: first.Value.value}
 		}
 
 		close(out)
 	}()
 
-	return First(out)
+	return First(out, options...)
 }
 
 // MapReduce transforms the input stream into a Go map using mapper and reducer functions.

--- a/reduce.go
+++ b/reduce.go
@@ -466,6 +466,7 @@ func MapReduce[A any, K comparable, V any](in <-chan Try[A], nm int, mapper func
 
 		// Error path: items can remain in the input, so we wait for the drain
 		if errSeen.Load() {
+			lists = nil // free memory while waiting for the drain
 			<-inputDrained
 			close(out)
 			return

--- a/reduce.go
+++ b/reduce.go
@@ -229,6 +229,7 @@ func Reduce[A any](in <-chan Try[A], n int, f func(A, A) (A, error), options ...
 
 		// Error path: items can remain in the input, so we wait for the drain
 		if errSeen.Load() {
+			nodes = nil // free memory while waiting for the drain
 			<-inputDrained
 			close(out)
 			return

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -23,165 +23,185 @@ func TestReduce(t *testing.T) {
 		th.RunSynctest(t, "empty", func(t *testing.T) {
 			in := FromSlice([]int{}, nil)
 
+			settled, opt := Settlement()
+
+			var calls int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
+				atomic.AddInt64(&calls, 1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			})
-
-			th.ExpectDrainedChan(t, in)
+			}, opt)
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
+
+			th.ExpectNoRace(calls)
+			th.ExpectDrainedChan(t, in)
+			th.ExpectValue(t, calls, 0)
+
+			<-settled // asserts that settlement is reported
 		})
 
 		th.RunSynctest(t, "single value stream", func(t *testing.T) {
 			in := FromSlice([]int{5}, nil)
 
-			var reducerCalls atomic.Int64
+			settled, opt := Settlement()
+
+			var calls int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				reducerCalls.Add(1)
+				atomic.AddInt64(&calls, 1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			})
-
-			th.ExpectDrainedChan(t, in)
+			}, opt)
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, out, 5)
 			th.ExpectValue(t, ok, true)
 
-			th.ExpectValue(t, reducerCalls.Load(), 0)
+			th.ExpectNoRace(calls)
+			th.ExpectDrainedChan(t, in)
+			th.ExpectValue(t, calls, 0) // never called
+
+			<-settled // asserts that settlement is reported
 		})
 
 		th.RunSynctest(t, "single error stream", func(t *testing.T) {
 			in := FromSlice([]int{}, fmt.Errorf("err0"))
 
+			settled, opt := Settlement()
+
+			var calls int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
+				atomic.AddInt64(&calls, 1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			})
-
-			th.WaitForInflightWork()
-			th.ExpectDrainedChan(t, in)
+			}, opt)
 
 			th.ExpectError(t, err, "err0")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
+
+			<-settled
+
+			th.ExpectNoRace(calls)
+			th.ExpectDrainedChan(t, in)
+			th.ExpectValue(t, calls, 0)
 		})
 
 		th.RunSynctest(t, "no errors", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 100), nil)
 
+			settled, opt := Settlement()
+
+			var calls int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
+				atomic.AddInt64(&calls, 1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			})
-
-			th.ExpectDrainedChan(t, in)
+			}, opt)
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, out, 99*100/2)
 			th.ExpectValue(t, ok, true)
-		})
 
-		th.RunSynctest(t, "concurrency", func(t *testing.T) {
-			in := FromChan(th.FromRange(0, 100), nil)
+			th.ExpectNoRace(calls)
+			th.ExpectDrainedChan(t, in)
+			th.ExpectValue(t, calls, 99)
 
-			var gauge th.InFlightGauge
-
-			_, _, _ = Reduce(in, n, func(x, y int) (int, error) {
-				gauge.Enter()
-				defer gauge.Exit()
-				th.SimulateWork(1*time.Second, 2*time.Second)
-
-				return x + y, nil
-			})
-
-			th.ExpectValue(t, gauge.Max(), n)
+			<-settled // asserts that settlement is reported
 		})
 
 		th.RunSynctest(t, "error in input", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = replaceWithError(in, 200, fmt.Errorf("err200"))
-			in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
 
-			var extraCalls atomic.Int64
+			settled, opt := Settlement()
+
+			var extraCalls int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				extraCalls.Add(1)
+				atomic.AddInt64(&extraCalls, 1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			})
-			extraCalls.Store(0)
+			}, opt)
+			atomic.StoreInt64(&extraCalls, 0)
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
 
-			_, inStillOpen := <-in
-			th.ExpectValue(t, inStillOpen, true)
-
-			th.WaitForInflightWork()
+			<-settled
+			th.ExpectNoRace(extraCalls)
 			th.ExpectDrainedChan(t, in)
 
 			if n == 1 {
-				th.ExpectValue(t, extraCalls.Load(), 0)
+				th.ExpectValue(t, extraCalls, 0)
 			} else {
-				th.ExpectBetween(t, extraCalls.Load(), 0, 50)
+				th.ExpectLTE(t, extraCalls, 50)
 			}
 		})
 
 		th.RunSynctest(t, "error in func", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
-			in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
 
-			var extraCalls atomic.Int64
-			var i atomic.Int64
+			settled, opt := Settlement()
+
+			var extraCalls int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				extraCalls.Add(1)
+				c := atomic.AddInt64(&extraCalls, 1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
-				if i.Add(1) == 200 {
+				if c == 200 {
 					return 0, fmt.Errorf("err200")
 				}
 				return x + y, nil
-			})
-			extraCalls.Store(0)
+			}, opt)
+			atomic.StoreInt64(&extraCalls, 0)
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
 
-			_, inStillOpen := <-in
-			th.ExpectValue(t, inStillOpen, true)
-
-			th.WaitForInflightWork()
+			<-settled
+			th.ExpectNoRace(extraCalls)
 			th.ExpectDrainedChan(t, in)
 
 			if n == 1 {
-				th.ExpectValue(t, extraCalls.Load(), 0)
+				th.ExpectValue(t, extraCalls, 0)
 			} else {
-				th.ExpectBetween(t, extraCalls.Load(), 0, 50)
+				th.ExpectLTE(t, extraCalls, 50)
 			}
+
 		})
 
 		th.RunSynctest(t, "error in func (last)", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 
-			var i atomic.Int64
-			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				th.SimulateWork(1*time.Second, 2*time.Second)
+			settled, opt := Settlement()
 
-				if i.Add(1) == 999 {
+			var extraCalls int64
+			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
+				c := atomic.AddInt64(&extraCalls, 1)
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				if c == 999 {
 					return 0, fmt.Errorf("err999")
 				}
 				return x + y, nil
-			})
+			}, opt)
+			atomic.StoreInt64(&extraCalls, 0)
 
 			th.ExpectError(t, err, "err999")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
 
+			<-settled
+			th.ExpectNoRace(extraCalls)
 			th.ExpectDrainedChan(t, in)
+
+			if n == 1 {
+				th.ExpectValue(t, extraCalls, 0)
+			} else {
+				th.ExpectLTE(t, extraCalls, 50)
+			}
 		})
 
 		t.Run("unclosed", func(t *testing.T) {
@@ -198,6 +218,22 @@ func TestReduce(t *testing.T) {
 				th.ExpectValue(t, out, 0)
 				th.ExpectValue(t, ok, false)
 			})
+		})
+
+		th.RunSynctest(t, "concurrency", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 100), nil)
+
+			var gauge th.InFlightGauge
+
+			_, _, _ = Reduce(in, n, func(x, y int) (int, error) {
+				gauge.Enter()
+				defer gauge.Exit()
+				th.SimulateWork(1*time.Second, 2*time.Second)
+
+				return x + y, nil
+			})
+
+			th.ExpectValue(t, gauge.Max(), n)
 		})
 
 		th.RunSynctest(t, "ordering", func(t *testing.T) {

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -40,7 +40,7 @@ func TestReduce(t *testing.T) {
 			th.ExpectDrainedChan(t, in)
 			th.ExpectValue(t, calls, 0)
 
-			<-settled // asserts that settlement is reported
+			<-settled // should not leak
 		})
 
 		th.RunSynctest(t, "single value stream", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestReduce(t *testing.T) {
 			th.ExpectDrainedChan(t, in)
 			th.ExpectValue(t, calls, 0) // never called
 
-			<-settled // asserts that settlement is reported
+			<-settled // should not leak
 		})
 
 		th.RunSynctest(t, "single error stream", func(t *testing.T) {
@@ -109,11 +109,12 @@ func TestReduce(t *testing.T) {
 			th.ExpectDrainedChan(t, in)
 			th.ExpectValue(t, calls, 99)
 
-			<-settled // asserts that settlement is reported
+			<-settled // should not leak
 		})
 
 		th.RunSynctest(t, "error in input", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
 			in = replaceWithError(in, 200, fmt.Errorf("err200"))
 
 			settled, opt := Settlement()
@@ -129,6 +130,7 @@ func TestReduce(t *testing.T) {
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
+			th.ExpectOpenChan(t, in)
 
 			<-settled
 			th.ExpectNoRace(extraCalls)
@@ -143,6 +145,7 @@ func TestReduce(t *testing.T) {
 
 		th.RunSynctest(t, "error in func", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
 
 			settled, opt := Settlement()
 
@@ -160,6 +163,7 @@ func TestReduce(t *testing.T) {
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
+			th.ExpectOpenChan(t, in)
 
 			<-settled
 			th.ExpectNoRace(extraCalls)
@@ -417,7 +421,7 @@ func TestMapReduce(t *testing.T) {
 			th.RunSynctest(t, "error in input", func(t *testing.T) {
 				in := FromChan(th.FromRange(0, 1000), nil)
 				in = replaceWithError(in, 200, fmt.Errorf("err200"))
-				in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
+				in = th.DelayEach(in, 1) // needed for inStillOpen assertion
 
 				var extraMapCalls, extraReduceCalls atomic.Int64
 				out, err := MapReduce(in,
@@ -455,7 +459,7 @@ func TestMapReduce(t *testing.T) {
 
 			th.RunSynctest(t, "error in mapper", func(t *testing.T) {
 				in := FromChan(th.FromRange(0, 1000), nil)
-				in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
+				in = th.DelayEach(in, 1) // needed for inStillOpen assertion
 
 				var extraMapCalls, extraReduceCalls atomic.Int64
 				var i atomic.Int64
@@ -497,7 +501,7 @@ func TestMapReduce(t *testing.T) {
 
 			th.RunSynctest(t, "error in reducer", func(t *testing.T) {
 				in := FromChan(th.FromRange(0, 1000), nil)
-				in = th.DelayEach(in, 1*time.Nanosecond) // needed for inStillOpen assertion
+				in = th.DelayEach(in, 1) // needed for inStillOpen assertion
 
 				var extraMapCalls, extraReduceCalls atomic.Int64
 				var i atomic.Int64

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -304,61 +304,69 @@ func TestMapReduce(t *testing.T) {
 			th.RunSynctest(t, "empty", func(t *testing.T) {
 				in := FromSlice([]int{}, nil)
 
+				var callsMapper, callsReducer atomic.Int64
 				out, err := MapReduce(in,
 					nm, func(x int) (string, int, error) {
+						callsMapper.Add(1)
 						th.SimulateWork(1*time.Second, 2*time.Second)
 						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
 					},
 					nr, func(x, y int) (int, error) {
+						callsReducer.Add(1)
 						th.SimulateWork(10*time.Second, 20*time.Second)
 						return x + y, nil
 					})
 
-				th.ExpectDrainedChan(t, in)
-
 				th.ExpectNoError(t, err)
 				th.ExpectMap(t, out, map[string]int{})
+				th.ExpectValue(t, callsMapper.Load(), 0)
+				th.ExpectValue(t, callsReducer.Load(), 0)
+				th.ExpectDrainedChan(t, in)
 			})
 
 			th.RunSynctest(t, "single error stream", func(t *testing.T) {
 				in := FromSlice([]int{}, fmt.Errorf("err0"))
 
+				var callsMapper, callsReducer atomic.Int64
 				out, err := MapReduce(in,
 					nm, func(x int) (string, int, error) {
+						callsMapper.Add(1)
 						th.SimulateWork(1*time.Second, 2*time.Second)
 						return fmt.Sprint(x), x, nil
 					},
 					nr, func(x, y int) (int, error) {
+						callsReducer.Add(1)
 						th.SimulateWork(1*time.Second, 2*time.Second)
 						return x + y, nil
 					},
 				)
 
-				th.WaitForInflightWork()
-				th.ExpectDrainedChan(t, in)
-
 				th.ExpectError(t, err, "err0")
 				th.ExpectMap(t, out, nil)
+
+				time.Sleep(24 * time.Hour) // eventually drained
+
+				th.ExpectValue(t, callsMapper.Load(), 0)
+				th.ExpectValue(t, callsReducer.Load(), 0)
+				th.ExpectDrainedChan(t, in)
 			})
 
 			th.RunSynctest(t, "single value keys", func(t *testing.T) {
 				in := FromSlice([]int{1, 2, 3, 4, 5}, nil)
 
-				var reducerCalls atomic.Int64
-
+				var callsMapper, callsReducer atomic.Int64
 				out, err := MapReduce(in,
 					nm, func(x int) (string, int, error) {
+						callsMapper.Add(1)
 						th.SimulateWork(1*time.Second, 2*time.Second)
 						return fmt.Sprint(x), x, nil
 					},
 					nr, func(x, y int) (int, error) {
-						reducerCalls.Add(1)
+						callsReducer.Add(1)
 						th.SimulateWork(10*time.Second, 20*time.Second)
 						return x + y, nil
 					},
 				)
-
-				th.ExpectDrainedChan(t, in)
 
 				th.ExpectNoError(t, err)
 				th.ExpectMap(t, out, map[string]int{
@@ -368,25 +376,27 @@ func TestMapReduce(t *testing.T) {
 					"4": 4,
 					"5": 5,
 				})
-
-				th.ExpectValue(t, reducerCalls.Load(), 0)
+				th.ExpectValue(t, callsMapper.Load(), 5)
+				th.ExpectValue(t, callsReducer.Load(), 0)
+				th.ExpectDrainedChan(t, in)
 			})
 
 			th.RunSynctest(t, "no errors", func(t *testing.T) {
 				in := FromChan(th.FromRange(0, 200), nil)
 
+				var callsMapper, callsReducer atomic.Int64
 				out, err := MapReduce(in,
 					nm, func(x int) (string, int, error) {
+						callsMapper.Add(1)
 						th.SimulateWork(1*time.Second, 2*time.Second)
 						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
 					},
 					nr, func(x, y int) (int, error) {
+						callsReducer.Add(1)
 						th.SimulateWork(10*time.Second, 20*time.Second)
 						return x + y, nil
 					},
 				)
-
-				th.ExpectDrainedChan(t, in)
 
 				th.ExpectNoError(t, err)
 				th.ExpectMap(t, out, map[string]int{
@@ -394,6 +404,229 @@ func TestMapReduce(t *testing.T) {
 					"2-digit": (10 + 99) * 90 / 2,
 					"3-digit": (100 + 199) * 100 / 2,
 				})
+				th.ExpectValue(t, callsMapper.Load(), 200)
+				th.ExpectValue(t, callsReducer.Load(), 9+89+99)
+				th.ExpectDrainedChan(t, in)
+			})
+
+			th.RunSynctest(t, "error in input", func(t *testing.T) {
+				in := FromChan(th.FromRange(0, 1000), nil)
+				in = replaceWithError(in, 200, fmt.Errorf("err200"))
+				in = th.DelayEach(in, 1)
+
+				var extraCallsMapper, extraCallsReducer atomic.Int64
+				out, err := MapReduce(in,
+					nm, func(x int) (string, int, error) {
+						extraCallsMapper.Add(1)
+						th.SimulateWork(1*time.Second, 2*time.Second)
+						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
+					},
+					nr, func(x, y int) (int, error) {
+						extraCallsReducer.Add(1)
+						th.SimulateWork(10*time.Second, 20*time.Second)
+						return x + y, nil
+					},
+				)
+				extraCallsMapper.Store(0)
+				extraCallsReducer.Store(0)
+
+				th.ExpectError(t, err, "err200")
+				th.ExpectMap(t, out, nil)
+				th.ExpectOpenChan(t, in)
+
+				time.Sleep(24 * time.Hour) // eventually drained
+
+				th.ExpectLTE(t, int(extraCallsMapper.Load()), when(nm == 1 && nr == 1, 0, 50))
+				th.ExpectLTE(t, int(extraCallsReducer.Load()), when(nr == 1, 0, 50))
+				th.ExpectDrainedChan(t, in)
+			})
+
+			th.RunSynctest(t, "error in mapper", func(t *testing.T) {
+				in := FromChan(th.FromRange(0, 1000), nil)
+				in = th.DelayEach(in, 1)
+
+				var extraCallsMapper, extraCallsReducer atomic.Int64
+				out, err := MapReduce(in,
+					nm, func(x int) (string, int, error) {
+						c := extraCallsMapper.Add(1)
+						th.SimulateWork(1*time.Second, 2*time.Second)
+						if c == 200 {
+							return "", 0, fmt.Errorf("err200")
+						}
+						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
+					},
+					nr, func(x, y int) (int, error) {
+						extraCallsReducer.Add(1)
+						th.SimulateWork(10*time.Second, 20*time.Second)
+						return x + y, nil
+					},
+				)
+				extraCallsMapper.Store(0)
+				extraCallsReducer.Store(0)
+
+				th.ExpectError(t, err, "err200")
+				th.ExpectMap(t, out, nil)
+				th.ExpectOpenChan(t, in)
+
+				time.Sleep(24 * time.Hour) // eventually drained
+
+				th.ExpectLTE(t, int(extraCallsMapper.Load()), when(nm == 1 && nr == 1, 0, 50))
+				th.ExpectLTE(t, int(extraCallsReducer.Load()), when(nr == 1, 0, 50))
+				th.ExpectDrainedChan(t, in)
+			})
+
+			th.RunSynctest(t, "error in reducer", func(t *testing.T) {
+				in := FromChan(th.FromRange(0, 1000), nil)
+				in = th.DelayEach(in, 1)
+
+				var extraCallsMapper, extraCallsReducer atomic.Int64
+				out, err := MapReduce(in,
+					nm, func(x int) (string, int, error) {
+						extraCallsMapper.Add(1)
+						th.SimulateWork(1*time.Second, 2*time.Second)
+						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
+					},
+					nr, func(x, y int) (int, error) {
+						c := extraCallsReducer.Add(1)
+						th.SimulateWork(10*time.Second, 20*time.Second)
+						if c == 200 {
+							return 0, fmt.Errorf("err200")
+						}
+						return x + y, nil
+					},
+				)
+				extraCallsMapper.Store(0)
+				extraCallsReducer.Store(0)
+
+				th.ExpectError(t, err, "err200")
+				th.ExpectMap(t, out, nil)
+				th.ExpectOpenChan(t, in)
+
+				time.Sleep(24 * time.Hour) // eventually drained
+
+				th.ExpectLTE(t, int(extraCallsMapper.Load()), when(nm == 1 && nr == 1, 0, 50))
+				th.ExpectLTE(t, int(extraCallsReducer.Load()), when(nr == 1, 0, 50))
+				th.ExpectDrainedChan(t, in)
+			})
+
+			th.RunSynctest(t, "error in reducer (last)", func(t *testing.T) {
+				in := FromChan(th.FromRange(0, 1000), nil)
+
+				var extraCallsMapper, extraCallsReducer atomic.Int64
+				out, err := MapReduce(in,
+					nm, func(x int) (string, int, error) {
+						extraCallsMapper.Add(1)
+						th.SimulateWork(1*time.Second, 2*time.Second)
+						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
+					},
+					nr, func(x, y int) (int, error) {
+						c := extraCallsReducer.Add(1)
+						th.SimulateWork(10*time.Second, 20*time.Second)
+						if c == 9+89+899 {
+							return 0, fmt.Errorf("errLast")
+						}
+						return x + y, nil
+					},
+				)
+				extraCallsMapper.Store(0)
+				extraCallsReducer.Store(0)
+
+				th.ExpectError(t, err, "errLast")
+				th.ExpectMap(t, out, nil)
+
+				time.Sleep(24 * time.Hour) // eventually drained
+
+				th.ExpectLTE(t, int(extraCallsMapper.Load()), 0)
+				th.ExpectLTE(t, int(extraCallsReducer.Load()), 0)
+				th.ExpectDrainedChan(t, in)
+			})
+
+			t.Run("unclosed", func(t *testing.T) {
+				th.ExpectLeak(t, func(t *testing.T) {
+					in := FromChan(th.FromRange(0, 1000), nil)
+					in = replaceWithError(in, 200, fmt.Errorf("err200"))
+					in = th.DontClose(in)
+
+					out, err := MapReduce(in,
+						nm, func(int) (string, int, error) {
+							return "", 0, nil
+						},
+						nr, func(int, int) (int, error) {
+							return 0, nil
+						},
+					)
+
+					th.ExpectError(t, err, "err200")
+					th.ExpectMap(t, out, nil)
+				})
+			})
+
+			th.RunSynctest(t, "settlement", func(t *testing.T) {
+				in := FromChan(th.FromRange(0, 200), nil)
+
+				settled, opt := Settlement()
+
+				var stateMapper, stateReducer int64
+				out, err := MapReduce(in,
+					nm, func(x int) (string, int, error) {
+						atomic.AddInt64(&stateMapper, 1)
+						th.SimulateWork(1*time.Second, 2*time.Second)
+						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
+					},
+					nr, func(x, y int) (int, error) {
+						atomic.AddInt64(&stateReducer, 1)
+						th.SimulateWork(10*time.Second, 20*time.Second)
+						return x + y, nil
+					},
+					opt,
+				)
+
+				th.ExpectNoError(t, err)
+				th.ExpectMap(t, out, map[string]int{
+					"1-digit": (0 + 9) * 10 / 2,
+					"2-digit": (10 + 99) * 90 / 2,
+					"3-digit": (100 + 199) * 100 / 2,
+				})
+				th.ExpectNoRace(stateMapper)
+				th.ExpectNoRace(stateReducer)
+				th.ExpectDrainedChan(t, in)
+
+				<-settled // should not leak
+			})
+
+			th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+				in := FromChan(th.FromRange(0, 1000), nil)
+				in = th.DelayEach(in, 1)
+
+				settled, opt := Settlement()
+
+				var stateMapper, stateReducer int64
+				out, err := MapReduce(in,
+					nm, func(x int) (string, int, error) {
+						atomic.AddInt64(&stateMapper, 1)
+						th.SimulateWork(1*time.Second, 2*time.Second)
+						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
+					},
+					nr, func(x, y int) (int, error) {
+						c := atomic.AddInt64(&stateReducer, 1)
+						th.SimulateWork(10*time.Second, 20*time.Second)
+						if c == 200 {
+							return 0, fmt.Errorf("err200")
+						}
+						return x + y, nil
+					},
+					opt,
+				)
+
+				th.ExpectError(t, err, "err200")
+				th.ExpectMap(t, out, nil)
+				th.ExpectOpenChan(t, in)
+
+				<-settled
+
+				th.ExpectNoRace(stateMapper)
+				th.ExpectNoRace(stateReducer)
+				th.ExpectDrainedChan(t, in)
 			})
 
 			th.RunSynctest(t, "concurrency", func(t *testing.T) {
@@ -424,173 +657,6 @@ func TestMapReduce(t *testing.T) {
 
 				th.ExpectValue(t, mapGauge.Max(), nm)
 				th.ExpectValue(t, reduceGauge.Max(), nr)
-			})
-
-			th.RunSynctest(t, "error in input", func(t *testing.T) {
-				in := FromChan(th.FromRange(0, 1000), nil)
-				in = replaceWithError(in, 200, fmt.Errorf("err200"))
-				in = th.DelayEach(in, 1) // needed for inStillOpen assertion
-
-				var extraMapCalls, extraReduceCalls atomic.Int64
-				out, err := MapReduce(in,
-					nm, func(x int) (string, int, error) {
-						extraMapCalls.Add(1)
-						th.SimulateWork(1*time.Second, 2*time.Second)
-						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
-					},
-					nr, func(x, y int) (int, error) {
-						extraReduceCalls.Add(1)
-						th.SimulateWork(10*time.Second, 20*time.Second)
-						return x + y, nil
-					},
-				)
-				extraMapCalls.Store(0)
-				extraReduceCalls.Store(0)
-
-				th.ExpectError(t, err, "err200")
-				th.ExpectMap(t, out, nil)
-
-				_, inStillOpen := <-in
-				th.ExpectValue(t, inStillOpen, true)
-
-				th.WaitForInflightWork()
-				th.ExpectDrainedChan(t, in)
-
-				if nm == 1 && nr == 1 {
-					th.ExpectValue(t, extraMapCalls.Load(), 0)
-					th.ExpectValue(t, extraReduceCalls.Load(), 0)
-				} else {
-					th.ExpectBetween(t, extraMapCalls.Load(), 0, 50)
-					th.ExpectBetween(t, extraReduceCalls.Load(), 0, 50)
-				}
-			})
-
-			th.RunSynctest(t, "error in mapper", func(t *testing.T) {
-				in := FromChan(th.FromRange(0, 1000), nil)
-				in = th.DelayEach(in, 1) // needed for inStillOpen assertion
-
-				var extraMapCalls, extraReduceCalls atomic.Int64
-				var i atomic.Int64
-				out, err := MapReduce(in,
-					nm, func(x int) (string, int, error) {
-						extraMapCalls.Add(1)
-						th.SimulateWork(1*time.Second, 2*time.Second)
-						if i.Add(1) == 200 {
-							return "", 0, fmt.Errorf("err200")
-						}
-						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
-					},
-					nr, func(x, y int) (int, error) {
-						extraReduceCalls.Add(1)
-						th.SimulateWork(10*time.Second, 20*time.Second)
-						return x + y, nil
-					},
-				)
-				extraMapCalls.Store(0)
-				extraReduceCalls.Store(0)
-
-				th.ExpectError(t, err, "err200")
-				th.ExpectMap(t, out, nil)
-
-				_, inStillOpen := <-in
-				th.ExpectValue(t, inStillOpen, true)
-
-				th.WaitForInflightWork()
-				th.ExpectDrainedChan(t, in)
-
-				if nm == 1 && nr == 1 {
-					th.ExpectValue(t, extraMapCalls.Load(), 0)
-					th.ExpectValue(t, extraReduceCalls.Load(), 0)
-				} else {
-					th.ExpectBetween(t, extraMapCalls.Load(), 0, 50)
-					th.ExpectBetween(t, extraReduceCalls.Load(), 0, 50)
-				}
-			})
-
-			th.RunSynctest(t, "error in reducer", func(t *testing.T) {
-				in := FromChan(th.FromRange(0, 1000), nil)
-				in = th.DelayEach(in, 1) // needed for inStillOpen assertion
-
-				var extraMapCalls, extraReduceCalls atomic.Int64
-				var i atomic.Int64
-				out, err := MapReduce(in,
-					nm, func(x int) (string, int, error) {
-						extraMapCalls.Add(1)
-						th.SimulateWork(1*time.Second, 2*time.Second)
-						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
-					},
-					nr, func(x, y int) (int, error) {
-						extraReduceCalls.Add(1)
-						th.SimulateWork(10*time.Second, 20*time.Second)
-						if i.Add(1) == 200 {
-							return 0, fmt.Errorf("err200")
-						}
-						return x + y, nil
-					},
-				)
-				extraMapCalls.Store(0)
-				extraReduceCalls.Store(0)
-
-				th.ExpectError(t, err, "err200")
-				th.ExpectMap(t, out, nil)
-
-				_, inStillOpen := <-in
-				th.ExpectValue(t, inStillOpen, true)
-
-				th.WaitForInflightWork()
-				th.ExpectDrainedChan(t, in)
-
-				if nm == 1 && nr == 1 {
-					th.ExpectValue(t, extraMapCalls.Load(), 0)
-					th.ExpectValue(t, extraReduceCalls.Load(), 0)
-				} else {
-					th.ExpectBetween(t, extraMapCalls.Load(), 0, 50)
-					th.ExpectBetween(t, extraReduceCalls.Load(), 0, 50)
-				}
-			})
-
-			th.RunSynctest(t, "error in reducer (last)", func(t *testing.T) {
-				in := FromChan(th.FromRange(0, 1000), nil)
-
-				var i atomic.Int64
-				out, err := MapReduce(in,
-					nm, func(x int) (string, int, error) {
-						th.SimulateWork(1*time.Second, 2*time.Second)
-						return fmt.Sprintf("%d-digit", len(fmt.Sprint(x))), x, nil
-					},
-					nr, func(x, y int) (int, error) {
-						th.SimulateWork(10*time.Second, 20*time.Second)
-						if i.Add(1) == 9+89+899 {
-							return 0, fmt.Errorf("err997")
-						}
-						return x + y, nil
-					},
-				)
-
-				th.ExpectDrainedChan(t, in)
-
-				th.ExpectError(t, err, "err997")
-				th.ExpectMap(t, out, nil)
-			})
-
-			t.Run("unclosed", func(t *testing.T) {
-				th.ExpectLeak(t, func(t *testing.T) {
-					in := FromChan(th.FromRange(0, 1000), nil)
-					in = replaceWithError(in, 200, fmt.Errorf("err200"))
-					in = th.DontClose(in)
-
-					out, err := MapReduce(in,
-						nm, func(int) (string, int, error) {
-							return "", 0, nil
-						},
-						nr, func(int, int) (int, error) {
-							return 0, nil
-						},
-					)
-
-					th.ExpectError(t, err, "err200")
-					th.ExpectMap(t, out, nil)
-				})
 			})
 
 			th.RunSynctest(t, "ordering", func(t *testing.T) {

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -72,8 +72,8 @@ func TestReduce(t *testing.T) {
 
 			time.Sleep(24 * time.Hour) // eventually drained
 
-			th.ExpectDrainedChan(t, in)
 			th.ExpectValue(t, calls.Load(), 0)
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "no errors", func(t *testing.T) {
@@ -96,8 +96,8 @@ func TestReduce(t *testing.T) {
 
 		th.RunSynctest(t, "error in input", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
-			in = th.DelayEach(in, 1)
 			in = replaceWithError(in, 200, fmt.Errorf("err200"))
+			in = th.DelayEach(in, 1)
 
 			var extraCalls atomic.Int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
@@ -110,7 +110,6 @@ func TestReduce(t *testing.T) {
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
-
 			th.ExpectOpenChan(t, in)
 
 			time.Sleep(24 * time.Hour) // eventually drained
@@ -165,7 +164,7 @@ func TestReduce(t *testing.T) {
 
 			time.Sleep(24 * time.Hour) // eventually drained
 
-			th.ExpectLTE(t, int(extraCalls.Load()), when(n == 1, 0, 50))
+			th.ExpectValue(t, extraCalls.Load(), 0)
 			th.ExpectDrainedChan(t, in)
 		})
 
@@ -191,16 +190,17 @@ func TestReduce(t *testing.T) {
 			settled, opt := Settlement()
 
 			var state int64
-			_, _, err := Reduce(in, n, func(x, y int) (int, error) {
+			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				atomic.AddInt64(&state, 1)
 				return x + y, nil
 			}, opt)
 
 			th.ExpectNoError(t, err)
+			th.ExpectValue(t, out, 99*100/2)
+			th.ExpectValue(t, ok, true)
 
 			th.ExpectNoRace(state)
-			th.ExpectValue(t, state, 99)
 			th.ExpectDrainedChan(t, in)
 
 			<-settled // should not leak
@@ -213,7 +213,7 @@ func TestReduce(t *testing.T) {
 			settled, opt := Settlement()
 
 			var state int64
-			_, _, err := Reduce(in, n, func(x, y int) (int, error) {
+			x, ok, err := Reduce(in, n, func(x, y int) (int, error) {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				if atomic.AddInt64(&state, 1) == 200 {
 					return 0, fmt.Errorf("err200")
@@ -222,6 +222,8 @@ func TestReduce(t *testing.T) {
 			}, opt)
 
 			th.ExpectError(t, err, "err200")
+			th.ExpectValue(t, x, 0)
+			th.ExpectValue(t, ok, false)
 			th.ExpectOpenChan(t, in)
 
 			<-settled

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -23,93 +23,75 @@ func TestReduce(t *testing.T) {
 		th.RunSynctest(t, "empty", func(t *testing.T) {
 			in := FromSlice([]int{}, nil)
 
-			settled, opt := Settlement()
-
-			var calls int64
+			var calls atomic.Int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				atomic.AddInt64(&calls, 1)
+				calls.Add(1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			}, opt)
+			})
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
 
-			th.ExpectNoRace(calls)
 			th.ExpectDrainedChan(t, in)
-			th.ExpectValue(t, calls, 0)
-
-			<-settled // should not leak
+			th.ExpectValue(t, calls.Load(), 0)
 		})
 
 		th.RunSynctest(t, "single value stream", func(t *testing.T) {
 			in := FromSlice([]int{5}, nil)
 
-			settled, opt := Settlement()
-
-			var calls int64
+			var calls atomic.Int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				atomic.AddInt64(&calls, 1)
+				calls.Add(1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			}, opt)
+			})
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, out, 5)
 			th.ExpectValue(t, ok, true)
 
-			th.ExpectNoRace(calls)
 			th.ExpectDrainedChan(t, in)
-			th.ExpectValue(t, calls, 0) // never called
-
-			<-settled // should not leak
+			th.ExpectValue(t, calls.Load(), 0) // never called
 		})
 
 		th.RunSynctest(t, "single error stream", func(t *testing.T) {
 			in := FromSlice([]int{}, fmt.Errorf("err0"))
 
-			settled, opt := Settlement()
-
-			var calls int64
+			var calls atomic.Int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				atomic.AddInt64(&calls, 1)
+				calls.Add(1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			}, opt)
+			})
 
 			th.ExpectError(t, err, "err0")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
 
-			<-settled
+			time.Sleep(24 * time.Hour) // eventually drained
 
-			th.ExpectNoRace(calls)
 			th.ExpectDrainedChan(t, in)
-			th.ExpectValue(t, calls, 0)
+			th.ExpectValue(t, calls.Load(), 0)
 		})
 
 		th.RunSynctest(t, "no errors", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 100), nil)
 
-			settled, opt := Settlement()
-
-			var calls int64
+			var calls atomic.Int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				atomic.AddInt64(&calls, 1)
+				calls.Add(1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			}, opt)
+			})
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, out, 99*100/2)
 			th.ExpectValue(t, ok, true)
 
-			th.ExpectNoRace(calls)
 			th.ExpectDrainedChan(t, in)
-			th.ExpectValue(t, calls, 99)
-
-			<-settled // should not leak
+			th.ExpectValue(t, calls.Load(), 99)
 		})
 
 		th.RunSynctest(t, "error in input", func(t *testing.T) {
@@ -117,95 +99,74 @@ func TestReduce(t *testing.T) {
 			in = th.DelayEach(in, 1)
 			in = replaceWithError(in, 200, fmt.Errorf("err200"))
 
-			settled, opt := Settlement()
-
-			var extraCalls int64
+			var extraCalls atomic.Int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				atomic.AddInt64(&extraCalls, 1)
+				extraCalls.Add(1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return x + y, nil
-			}, opt)
-			atomic.StoreInt64(&extraCalls, 0)
+			})
+			extraCalls.Store(0)
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
+
 			th.ExpectOpenChan(t, in)
 
-			<-settled
-			th.ExpectNoRace(extraCalls)
-			th.ExpectDrainedChan(t, in)
+			time.Sleep(24 * time.Hour) // eventually drained
 
-			if n == 1 {
-				th.ExpectValue(t, extraCalls, 0)
-			} else {
-				th.ExpectLTE(t, extraCalls, 50)
-			}
+			th.ExpectLTE(t, int(extraCalls.Load()), when(n == 1, 0, 50))
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "error in func", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = th.DelayEach(in, 1)
 
-			settled, opt := Settlement()
-
-			var extraCalls int64
+			var extraCalls atomic.Int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				c := atomic.AddInt64(&extraCalls, 1)
+				c := extraCalls.Add(1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				if c == 200 {
 					return 0, fmt.Errorf("err200")
 				}
 				return x + y, nil
-			}, opt)
-			atomic.StoreInt64(&extraCalls, 0)
+			})
+			extraCalls.Store(0)
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
 			th.ExpectOpenChan(t, in)
 
-			<-settled
-			th.ExpectNoRace(extraCalls)
+			time.Sleep(24 * time.Hour) // eventually drained
+
+			th.ExpectLTE(t, int(extraCalls.Load()), when(n == 1, 0, 50))
 			th.ExpectDrainedChan(t, in)
-
-			if n == 1 {
-				th.ExpectValue(t, extraCalls, 0)
-			} else {
-				th.ExpectLTE(t, extraCalls, 50)
-			}
-
 		})
 
 		th.RunSynctest(t, "error in func (last)", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 
-			settled, opt := Settlement()
-
-			var extraCalls int64
+			var extraCalls atomic.Int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
-				c := atomic.AddInt64(&extraCalls, 1)
+				c := extraCalls.Add(1)
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				if c == 999 {
 					return 0, fmt.Errorf("err999")
 				}
 				return x + y, nil
-			}, opt)
-			atomic.StoreInt64(&extraCalls, 0)
+			})
+			extraCalls.Store(0)
 
 			th.ExpectError(t, err, "err999")
 			th.ExpectValue(t, out, 0)
 			th.ExpectValue(t, ok, false)
 
-			<-settled
-			th.ExpectNoRace(extraCalls)
-			th.ExpectDrainedChan(t, in)
+			time.Sleep(24 * time.Hour) // eventually drained
 
-			if n == 1 {
-				th.ExpectValue(t, extraCalls, 0)
-			} else {
-				th.ExpectLTE(t, extraCalls, 50)
-			}
+			th.ExpectLTE(t, int(extraCalls.Load()), when(n == 1, 0, 50))
+			th.ExpectDrainedChan(t, in)
 		})
 
 		t.Run("unclosed", func(t *testing.T) {
@@ -222,6 +183,51 @@ func TestReduce(t *testing.T) {
 				th.ExpectValue(t, out, 0)
 				th.ExpectValue(t, ok, false)
 			})
+		})
+
+		th.RunSynctest(t, "settlement", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 100), nil)
+
+			settled, opt := Settlement()
+
+			var state int64
+			_, _, err := Reduce(in, n, func(x, y int) (int, error) {
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				atomic.AddInt64(&state, 1)
+				return x + y, nil
+			}, opt)
+
+			th.ExpectNoError(t, err)
+
+			th.ExpectNoRace(state)
+			th.ExpectValue(t, state, 99)
+			th.ExpectDrainedChan(t, in)
+
+			<-settled // should not leak
+		})
+
+		th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+			in := FromChan(th.FromRange(0, 1000), nil)
+			in = th.DelayEach(in, 1)
+
+			settled, opt := Settlement()
+
+			var state int64
+			_, _, err := Reduce(in, n, func(x, y int) (int, error) {
+				th.SimulateWork(1*time.Second, 2*time.Second)
+				if atomic.AddInt64(&state, 1) == 200 {
+					return 0, fmt.Errorf("err200")
+				}
+				return x + y, nil
+			}, opt)
+
+			th.ExpectError(t, err, "err200")
+			th.ExpectOpenChan(t, in)
+
+			<-settled
+
+			th.ExpectNoRace(state)
+			th.ExpectDrainedChan(t, in)
 		})
 
 		th.RunSynctest(t, "concurrency", func(t *testing.T) {

--- a/util.go
+++ b/util.go
@@ -23,9 +23,7 @@ func Discard[A any](in <-chan A, options ...SinkOption) {
 	select {
 	case _, ok := <-in:
 		if !ok {
-			if opts.settleChan != nil {
-				close(opts.settleChan)
-			}
+			opts.settle()
 			return
 		}
 	default:
@@ -34,9 +32,7 @@ func Discard[A any](in <-chan A, options ...SinkOption) {
 	// drain in background
 	go func() {
 		core.Drain(in)
-		if opts.settleChan != nil {
-			close(opts.settleChan)
-		}
+		opts.settle()
 	}()
 }
 

--- a/util.go
+++ b/util.go
@@ -6,21 +6,45 @@ import (
 	"github.com/destel/rill/internal/core"
 )
 
-// Drain consumes and discards all items from an input channel, blocking until the channel is closed.
+// Drain consumes and discards all items from an input channel, blocking until the channel is exhausted.
 func Drain[A any](in <-chan A) {
 	core.Drain(in)
 }
 
-// Discard is a non-blocking function that discards all items from an input channel.
-func Discard[A any](in <-chan A) {
-	core.Discard(in)
+// Discard returns immediately, consumes the input channel in the background, and discards all its items.
+func Discard[A any](in <-chan A, options ...SinkOption) {
+	opts := collectSinkOptions(options)
+
+	if in == nil {
+		return
+	}
+
+	// do nothing if the channel is already closed
+	select {
+	case _, ok := <-in:
+		if !ok {
+			if opts.settleChan != nil {
+				close(opts.settleChan)
+			}
+			return
+		}
+	default:
+	}
+
+	// drain in background
+	go func() {
+		core.Drain(in)
+		if opts.settleChan != nil {
+			close(opts.settleChan)
+		}
+	}()
 }
 
-// DrainNB is a non-blocking version of [Drain]. It does draining in a separate goroutine.
+// DrainNB returns immediately, consumes the input channel in the background, and discards all its items.
 //
 // Deprecated: use [Discard] instead. DrainNB will be removed in v1.0.
 func DrainNB[A any](in <-chan A) {
-	core.Discard(in)
+	Discard(in)
 }
 
 // Buffer takes a channel of items and returns a buffered channel of exact same items in the same order.

--- a/util_test.go
+++ b/util_test.go
@@ -36,8 +36,7 @@ func TestDiscard(t *testing.T) {
 		Discard(in) // doesn't block
 
 		time.Sleep(60 * time.Second)
-		_, stillOpen := <-in
-		th.ExpectTrue(t, stillOpen)
+		th.ExpectOpenChan(t, in)
 
 		time.Sleep(60 * time.Second)
 		th.ExpectDrainedChan(t, in)
@@ -51,8 +50,7 @@ func TestDiscard(t *testing.T) {
 		Discard(in, opt) // doesn't block
 
 		time.Sleep(60 * time.Second)
-		_, stillOpen := <-in
-		th.ExpectTrue(t, stillOpen)
+		th.ExpectOpenChan(t, in)
 
 		<-settled
 		th.ExpectDrainedChan(t, in)
@@ -74,7 +72,7 @@ func TestDiscard(t *testing.T) {
 
 		th.ExpectDrainedChan(t, in)
 
-		<-settled // important
+		<-settled // should not leak
 	})
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -3,13 +3,12 @@ package rill
 import (
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/destel/rill/internal/th"
 )
 
-// Full behavior of these functions is tested in the internal/core package.
-// Tests below only pin the wrapper wiring: right core function, args forwarded.
-
+// Drain is a wrapper around the function from the core package. The full behavior test is there.
 func TestDrain(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		in := th.FromRange(0, 10)
@@ -19,19 +18,67 @@ func TestDrain(t *testing.T) {
 }
 
 func TestDiscard(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		in := make(chan int)
-		Discard(in)
+	th.RunSynctest(t, "nil", func(t *testing.T) {
+		Discard[int](nil)
+	})
 
-		in <- 1
-		in <- 2
+	t.Run("nil w settlement", func(t *testing.T) {
+		th.ExpectBlock(t, func(t *testing.T) {
+			settled, opt := Settlement()
+			Discard[int](nil, opt)
+			<-settled
+		})
+	})
+
+	th.RunSynctest(t, "normal", func(t *testing.T) {
+		in := th.FromRange(0, 100)
+		in = th.DelayEach(in, 1*time.Second)
+		Discard(in) // doesn't block
+
+		time.Sleep(60 * time.Second)
+		_, stillOpen := <-in
+		th.ExpectTrue(t, stillOpen)
+
+		time.Sleep(60 * time.Second)
+		th.ExpectDrainedChan(t, in)
+	})
+
+	th.RunSynctest(t, "normal w settlement", func(t *testing.T) {
+		in := th.FromRange(0, 100)
+		in = th.DelayEach(in, 1*time.Second)
+
+		settled, opt := Settlement()
+		Discard(in, opt) // doesn't block
+
+		time.Sleep(60 * time.Second)
+		_, stillOpen := <-in
+		th.ExpectTrue(t, stillOpen)
+
+		<-settled
+		th.ExpectDrainedChan(t, in)
+	})
+
+	th.RunSynctest(t, "closed", func(t *testing.T) {
+		in := make(chan int)
+		close(in)
+		Discard(in)
+		th.ExpectDrainedChan(t, in)
+	})
+
+	th.RunSynctest(t, "closed w settlement", func(t *testing.T) {
+		in := make(chan int)
 		close(in)
 
-		synctest.Wait()
+		settled, opt := Settlement()
+		Discard(in, opt)
+
 		th.ExpectDrainedChan(t, in)
+
+		<-settled // important
 	})
 }
 
+// Buffer is a wrapper around the function from the core package. The full behavior test is there.
 func TestBuffer(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		in := make(chan int)

--- a/util_test.go
+++ b/util_test.go
@@ -56,6 +56,19 @@ func TestDiscard(t *testing.T) {
 		th.ExpectDrainedChan(t, in)
 	})
 
+	th.RunSynctest(t, "two settlements", func(t *testing.T) {
+		in := th.FromRange(0, 100)
+		in = th.DelayEach(in, 1*time.Second)
+
+		settled1, opt1 := Settlement()
+		settled2, opt2 := Settlement()
+		Discard(in, opt1, opt2) // doesn't block
+
+		<-settled1
+		th.ExpectDrainedChan(t, in)
+		<-settled2
+	})
+
 	th.RunSynctest(t, "closed", func(t *testing.T) {
 		in := make(chan int)
 		close(in)

--- a/wrap.go
+++ b/wrap.go
@@ -81,17 +81,16 @@ func FromSlice[A any](slice []A, err error) <-chan Try[A] {
 //
 // This is a blocking ordered function that processes items sequentially.
 // See the package documentation for more information on blocking ordered functions and error handling.
-func ToSlice[A any](in <-chan Try[A]) ([]A, error) {
-	var res []A
+func ToSlice[A any](in <-chan Try[A], options ...SinkOption) ([]A, error) {
+	defer Discard(in, options...)
 
+	var res []A
 	for x := range in {
 		if err := x.Error; err != nil {
-			Discard(in)
 			return res, err
 		}
 		res = append(res, x.Value)
 	}
-
 	return res, nil
 }
 

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/destel/rill/internal/th"
 )
@@ -77,25 +78,26 @@ func TestToSlice(t *testing.T) {
 
 		outSlice, err := ToSlice(in)
 
-		synctest.Wait()
-		th.ExpectDrainedChan(t, in)
-
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 		th.ExpectNoError(t, err)
+		th.ExpectDrainedChan(t, in)
 	})
 
 	th.RunSynctest(t, "errors", func(t *testing.T) {
 		in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)
 		in = replaceWithError(in, 5, fmt.Errorf("err005"))
 		in = replaceWithError(in, 7, fmt.Errorf("err007"))
+		in = th.DelayEach(in, 1)
 
 		outSlice, err := ToSlice(in)
 
-		synctest.Wait()
-		th.ExpectDrainedChan(t, in)
-
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4})
 		th.ExpectError(t, err, "err005")
+		th.ExpectOpenChan(t, in)
+
+		time.Sleep(24 * time.Hour) // eventually drained
+
+		th.ExpectDrainedChan(t, in)
 	})
 
 	t.Run("unclosed", func(t *testing.T) {
@@ -106,6 +108,37 @@ func TestToSlice(t *testing.T) {
 
 			_, _ = ToSlice(in)
 		})
+	})
+
+	th.RunSynctest(t, "settlement", func(t *testing.T) {
+		in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)
+
+		settled, opt := Settlement()
+		outSlice, err := ToSlice(in, opt)
+
+		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+		th.ExpectNoError(t, err)
+		th.ExpectDrainedChan(t, in)
+
+		<-settled // should not leak
+	})
+
+	th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+		in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)
+		in = replaceWithError(in, 5, fmt.Errorf("err005"))
+		in = replaceWithError(in, 7, fmt.Errorf("err007"))
+		in = th.DelayEach(in, 1)
+
+		settled, opt := Settlement()
+		outSlice, err := ToSlice(in, opt)
+
+		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4})
+		th.ExpectError(t, err, "err005")
+		th.ExpectOpenChan(t, in)
+
+		<-settled
+
+		th.ExpectDrainedChan(t, in)
 	})
 }
 


### PR DESCRIPTION
> This feature was replaced by the Scope API (#109)

Blocking sinks in rill return as soon as their outcome is known. That's deliberate – the sooner we get
control back, the sooner we can cancel the source that might still be producing work, and whatever is
still in flight across the pipeline stages.

What that model doesn't give us is an "everything is done" event. Sometimes we need one: to free a
shared resource, or to safely look at side effects the callbacks produced. Basically
`sync.WaitGroup.Wait()`, but for a pipeline. That's what we're adding.

```go
ctx, cancel := context.WithCancel(ctx)
defer cancel()

// other pipeline stages go here

settled, opt := rill.Settlement()

err := rill.ForEach(input, 5, func(x int) error {
	return process(ctx, x)
}, opt)

if err != nil {
	// handle
}

// stop the source and anything still in flight
cancel()  

// nothing from the pipeline runs after this
<-settled 

// now it's safe to free shared resources and observe side effects
```

One catch, and it's the whole reason `cancel()` is in that snippet: settlement doesn't stop anything, it
only tells us when the pipeline ran out of work. If the source keeps producing, we keep waiting, 
so stopping the source has to come first.

## How it works

We say a pipeline stage is settled once it won't do any more work: it has fully consumed its input, and
every callback it started has returned.

Most stages already expose this, they just don't call it that. `Map`, `Filter`, `FromSlice` and friends
close their output channel only after they've settled, so a closed output *is* the settlement signal.
Sinks (e.g. `ForEach`, `ToSlice`, `Reduce`) are the hole – no output channel, nothing to close, no signal. We give them an equivalent one.

The useful part is that it composes backwards. A settled sink means the stage before it closed its
output, which means that stage settled, which means the stage before *it* closed its output, and so on up
to the source. One signal at the end of a linear pipeline covers the whole thing. And it's a real
happens-before edge, not a timing coincidence – the tests pin that.

Two things to know:

- **Branching pipelines** (anything with `Tee`) need one settlement per terminal sink. A settled sink says
  nothing about callbacks still running in a sibling branch.
- **Custom stages** are covered as long as they play by the same rule: don't close the output until the
  input is consumed and the work is done.

## Compatibility

Existing call sites keep working, since the options are variadic. But every sink's signature changed, so
code that assigns a sink to an exact function type has to be updated. Technically, this is a breaking
API change.
