### PR TITLE
Add Scope API: context and settlement support

### DIFF
--- a/consume_test.go
+++ b/consume_test.go
@@ -61,7 +61,7 @@ func TestErr(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "context", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromChan(th.FromRange(0, 20), nil)
@@ -78,7 +78,7 @@ func TestErr(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "context (early return)", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromChan(th.FromRange(0, 20), nil)
@@ -176,7 +176,7 @@ func TestFirst(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "context", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromSlice([]int{}, nil)
@@ -195,7 +195,7 @@ func TestFirst(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "context (early return)", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromChan(th.FromRange(0, 20), nil)
@@ -301,7 +301,7 @@ func TestForEach(t *testing.T) {
 		})
 
 		th.RunSynctest(t, "context", func(t *testing.T) {
-			ctx, scope := WithContext(t.Context())
+			scope, ctx := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 20), nil)
@@ -325,7 +325,7 @@ func TestForEach(t *testing.T) {
 		})
 
 		th.RunSynctest(t, "context (early return)", func(t *testing.T) {
-			ctx, scope := WithContext(t.Context())
+			scope, ctx := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 1000), nil)
@@ -460,7 +460,7 @@ func TestAny(t *testing.T) {
 		})
 
 		th.RunSynctest(t, "context", func(t *testing.T) {
-			ctx, scope := WithContext(t.Context())
+			scope, ctx := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 100), nil)
@@ -481,7 +481,7 @@ func TestAny(t *testing.T) {
 		})
 
 		th.RunSynctest(t, "context (early return)", func(t *testing.T) {
-			ctx, scope := WithContext(t.Context())
+			scope, ctx := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 1000), nil)
@@ -601,7 +601,7 @@ func TestAll(t *testing.T) {
 		})
 
 		th.RunSynctest(t, "context", func(t *testing.T) {
-			ctx, scope := WithContext(t.Context())
+			scope, ctx := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 100), nil)
@@ -622,7 +622,7 @@ func TestAll(t *testing.T) {
 		})
 
 		th.RunSynctest(t, "context (early return)", func(t *testing.T) {
-			ctx, scope := WithContext(t.Context())
+			scope, ctx := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 1000), nil)

--- a/consume_test.go
+++ b/consume_test.go
@@ -1,6 +1,7 @@
 package rill
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -282,31 +283,35 @@ func TestForEach(t *testing.T) {
 			})
 		})
 
-		th.RunSynctest(t, "settlement", func(t *testing.T) {
+		th.RunSynctest(t, "context", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 20), nil)
 
-			settled, opt := Settlement()
+			ctx, scope := WithContext(context.Background())
+			defer scope.Cancel()
 
 			var state int64
 			err := ForEach(in, n, func(x int) error {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				atomic.AddInt64(&state, 1)
 				return nil
-			}, opt)
+			}, scope)
 
 			th.ExpectNoError(t, err)
 
 			th.ExpectNoRace(state)
 			th.ExpectDrainedChan(t, in)
+			th.ExpectActiveContext(t, ctx)
 
-			<-settled // should not leak
+			scope.Wait()
+			th.ExpectCanceledContext(t, ctx)
 		})
 
-		th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+		th.RunSynctest(t, "context (early return)", func(t *testing.T) {
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = th.DelayEach(in, 1)
 
-			settled, opt := Settlement()
+			ctx, scope := WithContext(context.Background())
+			defer scope.Cancel()
 
 			var state int64
 			err := ForEach(in, n, func(x int) error {
@@ -316,15 +321,17 @@ func TestForEach(t *testing.T) {
 				}
 				atomic.AddInt64(&state, 1)
 				return nil
-			}, opt)
+			}, scope)
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectOpenChan(t, in)
+			th.ExpectActiveContext(t, ctx)
 
-			<-settled
+			scope.Wait()
 
 			th.ExpectNoRace(state)
 			th.ExpectDrainedChan(t, in)
+			th.ExpectCanceledContext(t, ctx)
 		})
 
 	})

--- a/consume_test.go
+++ b/consume_test.go
@@ -1,7 +1,6 @@
 package rill
 
 import (
-	"context"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -61,32 +60,41 @@ func TestErr(t *testing.T) {
 		})
 	})
 
-	th.RunSynctest(t, "settlement", func(t *testing.T) {
+	th.RunSynctest(t, "context", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := FromChan(th.FromRange(0, 20), nil)
 
-		settled, opt := Settlement()
-		err := Err(in, opt)
+		err := Err(in, scope)
 
 		th.ExpectNoError(t, err)
 		th.ExpectDrainedChan(t, in)
+		th.ExpectActiveContext(t, ctx)
 
-		<-settled // should not leak
+		scope.Wait()
+
+		th.ExpectCanceledContext(t, ctx)
 	})
 
-	th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+	th.RunSynctest(t, "context (early return)", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := FromChan(th.FromRange(0, 20), nil)
 		in = replaceWithError(in, 10, fmt.Errorf("err010"))
 		in = th.DelayEach(in, 1)
 
-		settled, opt := Settlement()
-		err := Err(in, opt)
+		err := Err(in, scope)
 
 		th.ExpectError(t, err, "err010")
 		th.ExpectOpenChan(t, in)
+		th.ExpectActiveContext(t, ctx)
 
-		<-settled
+		scope.Wait()
 
 		th.ExpectDrainedChan(t, in)
+		th.ExpectCanceledContext(t, ctx)
 	})
 }
 
@@ -167,35 +175,44 @@ func TestFirst(t *testing.T) {
 		})
 	})
 
-	th.RunSynctest(t, "settlement", func(t *testing.T) {
+	th.RunSynctest(t, "context", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := FromSlice([]int{}, nil)
 
-		settled, opt := Settlement()
-		x, ok, err := First(in, opt)
+		x, ok, err := First(in, scope)
 
 		th.ExpectNoError(t, err)
 		th.ExpectValue(t, ok, false)
 		th.ExpectValue(t, x, 0)
 		th.ExpectDrainedChan(t, in)
+		th.ExpectActiveContext(t, ctx)
 
-		<-settled // should not leak
+		scope.Wait()
+
+		th.ExpectCanceledContext(t, ctx)
 	})
 
-	th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+	th.RunSynctest(t, "context (early return)", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := FromChan(th.FromRange(0, 20), nil)
 		in = th.DelayEach(in, 1)
 
-		settled, opt := Settlement()
-		x, ok, err := First(in, opt)
+		x, ok, err := First(in, scope)
 
 		th.ExpectNoError(t, err)
 		th.ExpectValue(t, ok, true)
 		th.ExpectValue(t, x, 0)
 		th.ExpectOpenChan(t, in)
+		th.ExpectActiveContext(t, ctx)
 
-		<-settled
+		scope.Wait()
 
 		th.ExpectDrainedChan(t, in)
+		th.ExpectCanceledContext(t, ctx)
 	})
 }
 
@@ -284,10 +301,10 @@ func TestForEach(t *testing.T) {
 		})
 
 		th.RunSynctest(t, "context", func(t *testing.T) {
-			in := FromChan(th.FromRange(0, 20), nil)
-
-			ctx, scope := WithContext(context.Background())
+			ctx, scope := WithContext(t.Context())
 			defer scope.Cancel()
+
+			in := FromChan(th.FromRange(0, 20), nil)
 
 			var state int64
 			err := ForEach(in, n, func(x int) error {
@@ -303,15 +320,16 @@ func TestForEach(t *testing.T) {
 			th.ExpectActiveContext(t, ctx)
 
 			scope.Wait()
+
 			th.ExpectCanceledContext(t, ctx)
 		})
 
 		th.RunSynctest(t, "context (early return)", func(t *testing.T) {
+			ctx, scope := WithContext(t.Context())
+			defer scope.Cancel()
+
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = th.DelayEach(in, 1)
-
-			ctx, scope := WithContext(context.Background())
-			defer scope.Cancel()
 
 			var state int64
 			err := ForEach(in, n, func(x int) error {
@@ -441,42 +459,51 @@ func TestAny(t *testing.T) {
 			th.ExpectValue(t, res, false)
 		})
 
-		th.RunSynctest(t, "settlement", func(t *testing.T) {
+		th.RunSynctest(t, "context", func(t *testing.T) {
+			ctx, scope := WithContext(t.Context())
+			defer scope.Cancel()
+
 			in := FromChan(th.FromRange(0, 100), nil)
 
-			settled, opt := Settlement()
 			res, err := Any(in, n, func(x int) (bool, error) {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return false, nil
-			}, opt)
+			}, scope)
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, false)
 			th.ExpectDrainedChan(t, in)
+			th.ExpectActiveContext(t, ctx)
 
-			<-settled // should not leak
+			scope.Wait()
+
+			th.ExpectCanceledContext(t, ctx)
 		})
 
-		th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+		th.RunSynctest(t, "context (early return)", func(t *testing.T) {
+			ctx, scope := WithContext(t.Context())
+			defer scope.Cancel()
+
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = th.DelayEach(in, 1)
 
-			settled, opt := Settlement()
 			res, err := Any(in, n, func(x int) (bool, error) {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				if x == 200 {
 					return true, nil
 				}
 				return false, nil
-			}, opt)
+			}, scope)
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, true)
 			th.ExpectOpenChan(t, in)
+			th.ExpectActiveContext(t, ctx)
 
-			<-settled
+			scope.Wait()
 
 			th.ExpectDrainedChan(t, in)
+			th.ExpectCanceledContext(t, ctx)
 		})
 	})
 }
@@ -573,42 +600,51 @@ func TestAll(t *testing.T) {
 			th.ExpectValue(t, res, false)
 		})
 
-		th.RunSynctest(t, "settlement", func(t *testing.T) {
+		th.RunSynctest(t, "context", func(t *testing.T) {
+			ctx, scope := WithContext(t.Context())
+			defer scope.Cancel()
+
 			in := FromChan(th.FromRange(0, 100), nil)
 
-			settled, opt := Settlement()
 			res, err := All(in, n, func(x int) (bool, error) {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				return true, nil
-			}, opt)
+			}, scope)
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, true)
 			th.ExpectDrainedChan(t, in)
+			th.ExpectActiveContext(t, ctx)
 
-			<-settled // should not leak
+			scope.Wait()
+
+			th.ExpectCanceledContext(t, ctx)
 		})
 
-		th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+		th.RunSynctest(t, "context (early return)", func(t *testing.T) {
+			ctx, scope := WithContext(t.Context())
+			defer scope.Cancel()
+
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = th.DelayEach(in, 1)
 
-			settled, opt := Settlement()
 			res, err := All(in, n, func(x int) (bool, error) {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				if x == 200 {
 					return false, nil
 				}
 				return true, nil
-			}, opt)
+			}, scope)
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, res, false)
 			th.ExpectOpenChan(t, in)
+			th.ExpectActiveContext(t, ctx)
 
-			<-settled
+			scope.Wait()
 
 			th.ExpectDrainedChan(t, in)
+			th.ExpectCanceledContext(t, ctx)
 		})
 	})
 }

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,7 @@ import (
 // Both operations are performed concurrently.
 // [ForEach] returns on the first error, and context cancellation via defer stops all remaining fetches.
 func Example() {
-	ctx, scope := rill.WithContext(context.Background())
+	scope, ctx := rill.NewScope(context.Background())
 	defer scope.Cancel()
 
 	// Convert a slice of user IDs into a stream
@@ -62,7 +62,7 @@ func Example() {
 // and updates their status to active and saves them back.
 // Users are fetched concurrently and in batches to reduce the number of API calls.
 func Example_batching() {
-	ctx, scope := rill.WithContext(context.Background())
+	scope, ctx := rill.NewScope(context.Background())
 	defer scope.Cancel()
 
 	// Convert a slice of user IDs into a stream
@@ -172,7 +172,7 @@ func updateUserTimestampWorker() {
 // [First] returns on the first match, this triggers the context cancellation via defer,
 // stopping URL generation and file downloads.
 func Example_orderingAndContext() {
-	ctx, scope := rill.WithContext(context.Background())
+	scope, ctx := rill.NewScope(context.Background())
 	defer scope.Cancel() // cancel all the remaining requests after the first match or error
 
 	// The string to search for in the downloaded files
@@ -219,7 +219,7 @@ func Example_orderingAndContext() {
 // This example demonstrates using [FlatMap] to fetch users from multiple departments concurrently.
 // Additionally, it demonstrates how to write a reusable streaming wrapper over paginated API calls - the StreamUsers function
 func Example_flatMap() {
-	ctx, scope := rill.WithContext(context.Background())
+	scope, ctx := rill.NewScope(context.Background())
 	defer scope.Cancel()
 
 	// Start with a stream of department names
@@ -282,7 +282,7 @@ func Example_context() {
 
 // CheckAllUsersExist uses several concurrent workers to check if all users with given IDs exist.
 func CheckAllUsersExist(ctx context.Context, concurrency int, ids []int) error {
-	ctx, scope := rill.WithContext(ctx)
+	scope, ctx := rill.NewScope(ctx)
 	defer scope.Cancel() // cancel the remaining requests after the first error
 
 	// Convert the slice into a stream
@@ -817,8 +817,8 @@ func ExampleToSeq2() {
 // [ForEach] returns as soon as the error is known, while the source and the remaining
 // workers are still going. [Scope.Wait] cancels the scope's Context and blocks
 // until all of them have stopped.
-func ExampleWithContext() {
-	ctx, scope := rill.WithContext(context.Background())
+func ExampleNewScope() {
+	scope, ctx := rill.NewScope(context.Background())
 	defer scope.Cancel() // extra cancel to make sure the context doesn't leak
 
 	// Use Generate instead of FromSlice to make the source context-aware

--- a/example_test.go
+++ b/example_test.go
@@ -24,8 +24,8 @@ import (
 // Both operations are performed concurrently.
 // [ForEach] returns on the first error, and context cancellation via defer stops all remaining fetches.
 func Example() {
-	scope, ctx := rill.NewScope(context.Background())
-	defer scope.Cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Convert a slice of user IDs into a stream
 	ids := rill.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil)
@@ -62,8 +62,8 @@ func Example() {
 // and updates their status to active and saves them back.
 // Users are fetched concurrently and in batches to reduce the number of API calls.
 func Example_batching() {
-	scope, ctx := rill.NewScope(context.Background())
-	defer scope.Cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Convert a slice of user IDs into a stream
 	ids := rill.FromSlice([]int{
@@ -172,8 +172,8 @@ func updateUserTimestampWorker() {
 // [First] returns on the first match, this triggers the context cancellation via defer,
 // stopping URL generation and file downloads.
 func Example_orderingAndContext() {
-	scope, ctx := rill.NewScope(context.Background())
-	defer scope.Cancel() // cancel all the remaining requests after the first match or error
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // cancel all the remaining requests after the first match or error
 
 	// The string to search for in the downloaded files
 	needle := []byte("26")
@@ -219,8 +219,8 @@ func Example_orderingAndContext() {
 // This example demonstrates using [FlatMap] to fetch users from multiple departments concurrently.
 // Additionally, it demonstrates how to write a reusable streaming wrapper over paginated API calls - the StreamUsers function
 func Example_flatMap() {
-	scope, ctx := rill.NewScope(context.Background())
-	defer scope.Cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Start with a stream of department names
 	departments := rill.FromSlice([]string{"IT", "Finance", "Marketing", "Support", "Engineering"}, nil)
@@ -282,8 +282,8 @@ func Example_context() {
 
 // CheckAllUsersExist uses several concurrent workers to check if all users with given IDs exist.
 func CheckAllUsersExist(ctx context.Context, concurrency int, ids []int) error {
-	scope, ctx := rill.NewScope(ctx)
-	defer scope.Cancel() // cancel the remaining requests after the first error
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel() // cancel the remaining requests after the first error
 
 	// Convert the slice into a stream
 	// (alternatively, use Generate instead of FromSlice to make the source context-aware)

--- a/example_test.go
+++ b/example_test.go
@@ -24,8 +24,8 @@ import (
 // Both operations are performed concurrently.
 // [ForEach] returns on the first error, and context cancellation via defer stops all remaining fetches.
 func Example() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, scope := rill.WithContext(context.Background())
+	defer scope.Cancel()
 
 	// Convert a slice of user IDs into a stream
 	ids := rill.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil)
@@ -62,8 +62,8 @@ func Example() {
 // and updates their status to active and saves them back.
 // Users are fetched concurrently and in batches to reduce the number of API calls.
 func Example_batching() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, scope := rill.WithContext(context.Background())
+	defer scope.Cancel()
 
 	// Convert a slice of user IDs into a stream
 	ids := rill.FromSlice([]int{
@@ -171,9 +171,9 @@ func updateUserTimestampWorker() {
 // while downloading and holding in memory at most 5 files at the same time.
 // [First] returns on the first match, this triggers the context cancellation via defer,
 // stopping URL generation and file downloads.
-func Example_ordering() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func Example_orderingAndContext() {
+	ctx, scope := rill.WithContext(context.Background())
+	defer scope.Cancel() // cancel all the remaining requests after the first match or error
 
 	// The string to search for in the downloaded files
 	needle := []byte("26")
@@ -219,8 +219,8 @@ func Example_ordering() {
 // This example demonstrates using [FlatMap] to fetch users from multiple departments concurrently.
 // Additionally, it demonstrates how to write a reusable streaming wrapper over paginated API calls - the StreamUsers function
 func Example_flatMap() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, scope := rill.WithContext(context.Background())
+	defer scope.Cancel()
 
 	// Start with a stream of department names
 	departments := rill.FromSlice([]string{"IT", "Finance", "Marketing", "Support", "Engineering"}, nil)
@@ -282,20 +282,12 @@ func Example_context() {
 
 // CheckAllUsersExist uses several concurrent workers to check if all users with given IDs exist.
 func CheckAllUsersExist(ctx context.Context, concurrency int, ids []int) error {
-	// Create new context that will be canceled when this function returns
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, scope := rill.WithContext(ctx)
+	defer scope.Cancel() // cancel the remaining requests after the first error
 
 	// Convert the slice into a stream
-	// Use Generate instead of FromSlice to make the first stage context-aware
-	idsStream := rill.Generate(func(send func(int), sendError func(error)) {
-		for _, id := range ids {
-			if ctx.Err() != nil {
-				return
-			}
-			send(id)
-		}
-	})
+	// (alternatively, use Generate instead of FromSlice to make the source context-aware)
+	idsStream := rill.FromSlice(ids, nil)
 
 	// Fetch users concurrently.
 	users := rill.Map(idsStream, concurrency, func(id int) (*mockapi.User, error) {
@@ -308,7 +300,7 @@ func CheckAllUsersExist(ctx context.Context, concurrency int, ids []int) error {
 		return u, nil
 	})
 
-	// Return the first error (if any) and cancel remaining fetches via context
+	// Return the first error (if any)
 	return rill.Err(users)
 }
 
@@ -692,55 +684,6 @@ func ExampleReduce() {
 	fmt.Println("Error:", err)
 }
 
-// This example demonstrates how to wait until the pipeline has no callbacks left to run.
-// [ForEach] returns as soon as the error is known, while the source and the remaining
-// workers are still going. Settlement reports when all of them have stopped.
-func ExampleSettlement() {
-	// Canceling this context stops the source and all in-flight work
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Use Generate instead of FromSlice to make the source context-aware
-	// and infinite
-	ids := rill.Generate(func(send func(int), sendError func(error)) {
-		for i := 1; ctx.Err() == nil; i++ {
-			send(i)
-		}
-	})
-
-	// Callbacks write here, so it's unsafe to touch while any of them is still running
-	var mu sync.Mutex
-	var seen []int
-
-	settled, opt := rill.Settlement()
-
-	// Process ids until one of them turns out to be bad
-	// Concurrency = 3
-	err := rill.ForEach(ids, 3, func(id int) error {
-		simulateWork(500 * time.Millisecond)
-
-		mu.Lock()
-		seen = append(seen, id)
-		mu.Unlock()
-
-		fmt.Println("Seen:", id)
-
-		if id == 15 {
-			return fmt.Errorf("bad id (%d)", id)
-		}
-
-		return nil
-	}, opt)
-	fmt.Println("* Returned:", err)
-
-	cancel()  // stop the source and the callbacks that are still running
-	<-settled // wait until none of them can touch seen anymore
-	fmt.Println("* Settled")
-
-	// No callback can be running now, so this needs no mutex
-	fmt.Println("Total seen:", len(seen))
-}
-
 func ExampleTee() {
 	// Convert a slice of numbers into a stream
 	numbers := rill.FromSlice([]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil)
@@ -868,6 +811,59 @@ func ExampleToSeq2() {
 		}
 		fmt.Printf("%+v\n", val)
 	}
+}
+
+// This example demonstrates how to wait until the pipeline has no callbacks left to run.
+// [ForEach] returns as soon as the error is known, while the source and the remaining
+// workers are still going. [Scope.Wait] cancels the scope's Context and blocks
+// until all of them have stopped.
+func ExampleWithContext() {
+	ctx, scope := rill.WithContext(context.Background())
+	defer scope.Cancel() // extra cancel to make sure the context doesn't leak
+
+	// Use Generate instead of FromSlice to make the source context-aware
+	// and infinite
+	ids := rill.Generate(func(send func(int), sendError func(error)) {
+		for i := 1; ctx.Err() == nil; i++ {
+			send(i)
+		}
+	})
+
+	// Callbacks write here, so it's unsafe to touch while any of them is still running
+	var mu sync.Mutex
+	var seen []int
+
+	// Process ids until one of them turns out to be bad.
+	// Callbacks have a side effect: they write to the `seen` slice.
+	// Concurrency = 3
+	err := rill.ForEach(ids, 3, func(id int) error {
+		simulateWork(500 * time.Millisecond)
+
+		mu.Lock()
+		seen = append(seen, id)
+		mu.Unlock()
+
+		fmt.Println("Seen:", id)
+
+		if id == 15 {
+			return fmt.Errorf("bad id (%d)", id)
+		}
+
+		return nil
+	}, scope)
+	fmt.Println("* Returned:", err)
+
+	// Wait until the pipeline is settled:
+	// source is stopped and all remaining callbacks are finished.
+	//
+	// If we don't need to access side effects created by the pipeline,
+	// we can just return here and let `defer scope.Cancel()` handle the cleanup.
+	scope.Wait()
+	fmt.Println("* Settled")
+
+	// No callback can be running now, the `seen` slice is now
+	// stable and safe-to-read w/o the mutex.
+	fmt.Println("Total seen:", len(seen))
 }
 
 // --- Helpers ---

--- a/internal/th/assertions.go
+++ b/internal/th/assertions.go
@@ -3,6 +3,7 @@ package th
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -118,13 +119,27 @@ func ExpectDrainedChan[A any](t *testing.T, ch <-chan A) {
 	}
 }
 
-// ExpectOpenChan consumes one item from the channel and asserts that the
-// channel was open. It blocks until an item arrives or the channel is closed.
+// ExpectOpenChan checks that the channel emits another item rather than closing.
+// The operation is destructive and blocks until either an item arrives or the channel is closed.
 func ExpectOpenChan[A any](t *testing.T, ch <-chan A) {
 	t.Helper()
 	_, isOpen := <-ch
 	if !isOpen {
 		t.Errorf("expected channel to be open, but it's closed")
+	}
+}
+
+func ExpectCanceledContext(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if err := ctx.Err(); err == nil {
+		t.Errorf("expected context to be canceled")
+	}
+}
+
+func ExpectActiveContext(t *testing.T, ctx context.Context) {
+	t.Helper()
+	if err := ctx.Err(); err != nil {
+		t.Errorf("expected context to be active, but it's canceled")
 	}
 }
 

--- a/iter.go
+++ b/iter.go
@@ -51,9 +51,9 @@ func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
 // Errors are yielded as ordinary pairs and do not stop the iteration;
 // handle them inside the loop.
 //
-// The returned iterator is single-use. If the caller stops iteration early
-// using break or return, ToSeq2 drains the remaining input in the background
-// to settle the pipeline.
+// ToSeq2 returns a single-use iterator, which must be called for the pipeline
+// to settle. If iteration stops early using break or return, ToSeq2 drains the
+// remaining input in the background.
 func ToSeq2[A any](in <-chan Try[A], options ...SinkOption) iter.Seq2[A, error] {
 	// Unlike other sinks, ToSeq2 opens the options at the call site: its work
 	// happens while the iterator is ranged, which can be arbitrarily far from

--- a/iter.go
+++ b/iter.go
@@ -52,20 +52,37 @@ func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
 // handle them inside the loop.
 //
 // If the caller stops iteration early using break or return, ToSeq2 drains the
-// remaining input in the background, like blocking functions such as [ForEach].
-//
-// The returned iterator is single-use. If it is never ranged, the input is
-// never drained.
+// remaining input in the background to settle the pipeline.
 func ToSeq2[A any](in <-chan Try[A], options ...SinkOption) iter.Seq2[A, error] {
+	// Unlike other sinks, ToSeq2 opens the options at the call site: its work
+	// happens while the iterator is ranged, which can be arbitrarily far from
+	// here.
+	opts := collectSinkOptions(options)
+
+	// The options are opened once, so they must also be settled once.
 	var once sync.Once
 
 	return func(yield func(A, error) bool) {
-		defer once.Do(func() { Discard(in, options...) })
+		endReached := false
+
+		defer once.Do(func() {
+			if endReached {
+				opts.settle()
+				return
+			}
+
+			go func() {
+				Drain(in)
+				opts.settle()
+			}()
+		})
 
 		for x := range in {
 			if !yield(x.Value, x.Error) {
 				return
 			}
 		}
+
+		endReached = true
 	}
 }

--- a/iter.go
+++ b/iter.go
@@ -51,8 +51,9 @@ func FromSeq2[A any](seq iter.Seq2[A, error]) <-chan Try[A] {
 // Errors are yielded as ordinary pairs and do not stop the iteration;
 // handle them inside the loop.
 //
-// If the caller stops iteration early using break or return, ToSeq2 drains the
-// remaining input in the background to settle the pipeline.
+// The returned iterator is single-use. If the caller stops iteration early
+// using break or return, ToSeq2 drains the remaining input in the background
+// to settle the pipeline.
 func ToSeq2[A any](in <-chan Try[A], options ...SinkOption) iter.Seq2[A, error] {
 	// Unlike other sinks, ToSeq2 opens the options at the call site: its work
 	// happens while the iterator is ranged, which can be arbitrarily far from

--- a/iter_test.go
+++ b/iter_test.go
@@ -101,11 +101,13 @@ func TestToSeq2(t *testing.T) {
 		})
 	})
 
-	th.RunSynctest(t, "settlement", func(t *testing.T) {
+	th.RunSynctest(t, "context", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := FromChan(th.FromRange(0, 10), nil)
 
-		settled, opt := Settlement()
-		out := ToSeq2(in, opt)
+		out := ToSeq2(in, scope)
 
 		var outSlice []int
 		for val := range out {
@@ -114,16 +116,21 @@ func TestToSeq2(t *testing.T) {
 
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 		th.ExpectDrainedChan(t, in)
+		th.ExpectActiveContext(t, ctx)
 
-		<-settled // should not leak
+		scope.Wait()
+
+		th.ExpectCanceledContext(t, ctx)
 	})
 
-	th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+	th.RunSynctest(t, "context (early return)", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := FromChan(th.FromRange(0, 10), nil)
 		in = th.DelayEach(in, 1)
 
-		settled, opt := Settlement()
-		out := ToSeq2(in, opt)
+		out := ToSeq2(in, scope)
 
 		var outSlice []int
 		for val := range out {
@@ -135,25 +142,41 @@ func TestToSeq2(t *testing.T) {
 
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4})
 		th.ExpectOpenChan(t, in)
+		th.ExpectActiveContext(t, ctx)
 
-		<-settled
+		scope.Wait()
 
+		th.ExpectDrainedChan(t, in)
+		th.ExpectCanceledContext(t, ctx)
+	})
+
+	th.RunSynctest(t, "context (double consumption)", func(t *testing.T) {
+		_, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
+		in := FromChan(th.FromRange(0, 20), nil)
+
+		out := ToSeq2(in, scope)
+
+		for range out {
+		}
+		for range out {
+		}
+
+		scope.Wait()
 		th.ExpectDrainedChan(t, in)
 	})
 
-	th.RunSynctest(t, "settlement (double consumption does not panic)", func(t *testing.T) {
-		in := FromChan(th.FromRange(0, 20), nil)
+	t.Run("context (never ranged)", func(t *testing.T) {
+		th.ExpectBlock(t, func(t *testing.T) {
+			_, scope := WithContext(t.Context())
+			defer scope.Cancel()
 
-		settled, opt := Settlement()
-		out := ToSeq2(in, opt)
+			in := FromChan(th.FromRange(0, 20), nil)
+			_ = ToSeq2(in, scope) // ignore the iterator
 
-		for range out {
-		}
-		for range out {
-		}
-
-		<-settled // asserts that settlement is reported
-		th.ExpectDrainedChan(t, in)
+			scope.Wait() // this blocks forever
+		})
 	})
 }
 

--- a/iter_test.go
+++ b/iter_test.go
@@ -102,7 +102,7 @@ func TestToSeq2(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "context", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromChan(th.FromRange(0, 10), nil)
@@ -124,7 +124,7 @@ func TestToSeq2(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "context (early return)", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromChan(th.FromRange(0, 10), nil)
@@ -151,7 +151,7 @@ func TestToSeq2(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "context (double consumption)", func(t *testing.T) {
-		_, scope := WithContext(t.Context())
+		scope, _ := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromChan(th.FromRange(0, 20), nil)
@@ -169,7 +169,7 @@ func TestToSeq2(t *testing.T) {
 
 	t.Run("context (never ranged)", func(t *testing.T) {
 		th.ExpectBlock(t, func(t *testing.T) {
-			_, scope := WithContext(t.Context())
+			scope, _ := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 20), nil)

--- a/options.go
+++ b/options.go
@@ -1,10 +1,6 @@
 package rill
 
-import (
-	"context"
-	"sync"
-	"sync/atomic"
-)
+import "sync/atomic"
 
 type sinkOptions struct {
 	settleFuncs []func()
@@ -68,91 +64,4 @@ func Settlement() (settled <-chan struct{}, opt SinkOption) {
 		options.settleFuncs = append(options.settleFuncs, func() { close(ch) })
 	})
 	return
-}
-
-// A Scope tracks the lifecycle of a pipeline and lets the caller wait until
-// all of its work is done - including any work that happens after a sink's
-// early return.
-//
-// A scope passed to a sink as a [SinkOption] tracks not only that sink, but
-// also the whole pipeline behind it.
-//
-// For branching pipelines (see [Tee]), multiple sinks can be attached to the
-// same scope.
-type Scope interface {
-	SinkOption
-
-	// Cancel cancels the scope's Context. It does not wait for the work
-	// to finish.
-	Cancel()
-
-	// Wait is called after the sink has returned. It cancels the scope's
-	// Context and blocks until the pipeline has settled: every user callback
-	// has returned and any other remaining work is finished.
-	//
-	// Wait can be called any number of times and from multiple goroutines,
-	// but only after every sink attached to the scope has returned.
-	// Attaching a new sink to the scope after Wait has been called panics.
-	Wait()
-}
-
-type scope struct {
-	cancelFunc context.CancelFunc
-
-	mu         sync.Mutex
-	cond       sync.Cond
-	cnt        int
-	waitCalled bool
-}
-
-func (s *scope) apply(options *sinkOptions) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// Any join after Wait was called means Wait was called too early: the sink
-	// had not returned yet, so Wait could not have covered it.
-	if s.waitCalled {
-		panic("rill: Wait must be called after all sinks attached to the scope have returned")
-	}
-
-	s.cnt++
-	options.settleFuncs = append(options.settleFuncs, s.release)
-}
-
-func (s *scope) release() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.cnt--
-	s.cond.Broadcast()
-}
-
-func (s *scope) Cancel() {
-	s.cancelFunc()
-}
-
-func (s *scope) Wait() {
-	s.cancelFunc()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.waitCalled = true
-	for s.cnt > 0 {
-		s.cond.Wait()
-	}
-}
-
-// WithContext creates a new [Scope] and an associated Context derived from ctx.
-//
-// The Context is canceled by [Scope.Cancel] or [Scope.Wait]. At least one
-// of them must be called, typically via defer, to prevent the Context from
-// leaking.
-func WithContext(ctx context.Context) (context.Context, Scope) {
-	ctx, cancel := context.WithCancel(ctx)
-
-	s := &scope{cancelFunc: cancel}
-	s.cond.L = &s.mu
-
-	return ctx, s
 }

--- a/options.go
+++ b/options.go
@@ -1,20 +1,23 @@
 package rill
 
-import "sync/atomic"
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
 
 type sinkOptions struct {
-	settleChans []chan struct{}
+	settleFuncs []func()
 }
 
 func (o sinkOptions) settle() {
-	for _, ch := range o.settleChans {
-		close(ch)
+	for _, fn := range o.settleFuncs {
+		fn()
 	}
 }
 
-// A SinkOption is an optional argument accepted by every sink, such as the
-// one returned by [Settlement]. The interface cannot be implemented outside
-// this package.
+// A SinkOption is an optional argument accepted by every sink, such as a
+// [Scope]. The interface cannot be implemented outside this package.
 type SinkOption interface {
 	apply(options *sinkOptions)
 }
@@ -62,7 +65,94 @@ func Settlement() (settled <-chan struct{}, opt SinkOption) {
 			panic("rill: the same settlement option used more than once")
 		}
 
-		options.settleChans = append(options.settleChans, ch)
+		options.settleFuncs = append(options.settleFuncs, func() { close(ch) })
 	})
 	return
+}
+
+// A Scope tracks the lifecycle of a pipeline and lets the caller wait until
+// all of its work is done - including any work that happens after a sink's
+// early return.
+//
+// A scope passed to a sink as a [SinkOption] tracks not only that sink, but
+// also the whole pipeline behind it.
+//
+// For branching pipelines (see [Tee]), multiple sinks can be attached to the
+// same scope.
+type Scope interface {
+	SinkOption
+
+	// Cancel cancels the scope's Context. It does not wait for the work
+	// to finish.
+	Cancel()
+
+	// Wait is called after the sink has returned. It cancels the scope's
+	// Context and blocks until the pipeline has settled: every user callback
+	// has returned and any other remaining work is finished.
+	//
+	// Wait can be called any number of times and from multiple goroutines,
+	// but only after every sink attached to the scope has returned.
+	// Attaching a new sink to the scope after Wait has been called panics.
+	Wait()
+}
+
+type scope struct {
+	cancelFunc context.CancelFunc
+
+	mu         sync.Mutex
+	cond       sync.Cond
+	cnt        int
+	waitCalled bool
+}
+
+func (s *scope) apply(options *sinkOptions) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Any join after Wait was called means Wait was called too early: the sink
+	// had not returned yet, so Wait could not have covered it.
+	if s.waitCalled {
+		panic("rill: Wait must be called after all sinks attached to the scope have returned")
+	}
+
+	s.cnt++
+	options.settleFuncs = append(options.settleFuncs, s.release)
+}
+
+func (s *scope) release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.cnt--
+	s.cond.Broadcast()
+}
+
+func (s *scope) Cancel() {
+	s.cancelFunc()
+}
+
+func (s *scope) Wait() {
+	s.cancelFunc()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.waitCalled = true
+	for s.cnt > 0 {
+		s.cond.Wait()
+	}
+}
+
+// WithContext creates a new [Scope] and an associated Context derived from ctx.
+//
+// The Context is canceled by [Scope.Cancel] or [Scope.Wait]. At least one
+// of them must be called, typically via defer, to prevent the Context from
+// leaking.
+func WithContext(ctx context.Context) (context.Context, Scope) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	s := &scope{cancelFunc: cancel}
+	s.cond.L = &s.mu
+
+	return ctx, s
 }

--- a/options.go
+++ b/options.go
@@ -1,7 +1,5 @@
 package rill
 
-import "sync/atomic"
-
 type sinkOptions struct {
 	settleFuncs []func()
 }
@@ -18,12 +16,6 @@ type SinkOption interface {
 	apply(options *sinkOptions)
 }
 
-type sinkOptionFunc func(options *sinkOptions)
-
-func (f sinkOptionFunc) apply(options *sinkOptions) {
-	f(options)
-}
-
 func collectSinkOptions(options []SinkOption) sinkOptions {
 	var result sinkOptions
 	for _, option := range options {
@@ -33,35 +25,4 @@ func collectSinkOptions(options []SinkOption) sinkOptions {
 		option.apply(&result)
 	}
 	return result
-}
-
-// Settlement reports when the pipeline has no callbacks left to run. It
-// returns the signal channel and the option that enables it. The option
-// must not be reused across sinks.
-//
-// A pipeline settles when every callback started by the sink and its
-// upstream stages has returned, including the ones that kept running
-// after the result was known. No callback runs after that.
-//
-// Settlement does not stop the pipeline: unless the source is stopped
-// first, the channel is closed only after the entire input is consumed.
-// With an infinite source, that never happens.
-func Settlement() (settled <-chan struct{}, opt SinkOption) {
-	ch := make(chan struct{})
-	settled = ch
-
-	var cnt atomic.Int32
-
-	opt = sinkOptionFunc(func(options *sinkOptions) {
-		// This fires when the options are opened, i.e. at sink return rather
-		// than at the call site. Detecting reuse at sink entry would require
-		// re-plumbing every sink chain - too costly in the current architecture
-		// for what it buys.
-		if cnt.Add(1) > 1 {
-			panic("rill: the same settlement option used more than once")
-		}
-
-		options.settleFuncs = append(options.settleFuncs, func() { close(ch) })
-	})
-	return
 }

--- a/options_test.go
+++ b/options_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSinkOption(t *testing.T) {
 	t.Run("nil options are ignored", func(t *testing.T) {
-		_, scope := WithContext(t.Context())
+		scope, _ := NewScope(t.Context())
 		defer scope.Cancel()
 
 		opts := collectSinkOptions([]SinkOption{nil, scope, nil})

--- a/options_test.go
+++ b/options_test.go
@@ -8,22 +8,10 @@ import (
 
 func TestSinkOption(t *testing.T) {
 	t.Run("nil options are ignored", func(t *testing.T) {
-		_, opt := Settlement()
+		_, scope := WithContext(t.Context())
+		defer scope.Cancel()
 
-		opts := collectSinkOptions([]SinkOption{nil, opt, nil})
+		opts := collectSinkOptions([]SinkOption{nil, scope, nil})
 		th.ExpectValue(t, len(opts.settleFuncs), 1)
-	})
-
-	t.Run("settlement can't be reused", func(t *testing.T) {
-		_, opt := Settlement()
-		_, _, _ = First(FromSlice([]int{}, nil), opt)
-
-		defer func() {
-			if recover() == nil {
-				t.Fatal("expected panic")
-			}
-		}()
-
-		_, _, _ = First(FromSlice([]int{}, nil), opt)
 	})
 }

--- a/options_test.go
+++ b/options_test.go
@@ -11,7 +11,7 @@ func TestSinkOption(t *testing.T) {
 		_, opt := Settlement()
 
 		opts := collectSinkOptions([]SinkOption{nil, opt, nil})
-		th.ExpectValue(t, len(opts.settleChans), 1)
+		th.ExpectValue(t, len(opts.settleFuncs), 1)
 	})
 
 	t.Run("settlement can't be reused", func(t *testing.T) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -56,7 +56,7 @@ func TestPipelines(t *testing.T) {
 
 	// Find the first palindromic number greater than 123456.
 	th.RunSynctest(t, "context", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		// shared state, mutated with atomics by the stages

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,7 +1,6 @@
 package rill
 
 import (
-	"context"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -56,9 +55,9 @@ func TestPipelines(t *testing.T) {
 	})
 
 	// Find the first palindromic number greater than 123456.
-	th.RunSynctest(t, "settlement", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+	th.RunSynctest(t, "context", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
 
 		// shared state, mutated with atomics by the stages
 		var totalCalls int64
@@ -80,17 +79,13 @@ func TestPipelines(t *testing.T) {
 			return isPalindrome(x), nil
 		})
 
-		settled, opt := Settlement()
-		res, _, err := First(palindromes, opt)
-
-		// stop the source from generating more numbers
-		cancel()
+		res, _, err := First(palindromes, scope)
 
 		th.ExpectNoError(t, err)
 		th.ExpectValue(t, res, "124421")
 
-		// wait for the pipeline to settle (no more callbacks)
-		<-settled
+		// stop the source and wait for the pipeline to settle (no more callbacks)
+		scope.Wait()
 
 		// shared state is now safe to read without atomics
 		th.ExpectNoRace(totalCalls)

--- a/reduce.go
+++ b/reduce.go
@@ -211,38 +211,37 @@ func Reduce[A any](in <-chan Try[A], n int, f func(A, A) (A, error), options ...
 		}
 	}
 
-	inputDrained, opt := Settlement()
-	defer Discard(in, opt)
-
 	// Start the workers
 	var wg sync.WaitGroup
 	for range n {
 		wg.Go(worker)
 	}
 
-	// Wait until all workers quit
+	// Collect the result once all workers have quit, then close out
 	go func() {
 		wg.Wait()
 
-		// The out channel propagates both the result and the settlement signal to First.
-		// We're only allowed to close it after the input is drained.
-
-		// Error path: items can remain in the input, so we wait for the drain
-		if errSeen.Load() {
-			nodes = nil // free memory while waiting for the drain
-			<-inputDrained
-			close(out)
-			return
+		if !errSeen.Load() {
+			// By construction, the list contains 0 or 1 nodes.
+			if first := nodes.Front(); first != nil {
+				out <- Try[A]{Value: first.Value.value}
+			}
 		}
 
-		// Happy path: the workers exhausted the input, so there is nothing to
-		// drain. By construction, the list contains 0 or 1 nodes.
-		if first := nodes.Front(); first != nil {
-			out <- Try[A]{Value: first.Value.value}
-		}
+		nodes = nil // free memory before the drain below
+
+		// This drain is needed for correctness:
+		// out chan carries settlement signal,
+		// don't close it until the input is drained.
+		Drain(in)
 
 		close(out)
 	}()
+
+	// This discard is needed for promptness:
+	// it starts earlier than the drain above - when the result is known.
+	// It takes no options: the settlement signal is carried by out, not in.
+	defer Discard(in)
 
 	return First(out, options...)
 }
@@ -449,40 +448,40 @@ func MapReduce[A any, K comparable, V any](in <-chan Try[A], nm int, mapper func
 		}
 	}
 
-	inputDrained, opt := Settlement()
-	defer Discard(entries, opt)
-
 	// Start the workers
 	var wg sync.WaitGroup
 	for range nr {
 		wg.Go(worker)
 	}
 
-	// Wait until all workers quit, then harvest the final map
+	// Collect the result once all workers have quit, then close out
 	go func() {
 		wg.Wait()
 
-		// The out channel propagates both the result and the settlement signal to First.
-		// We're only allowed to close it after the input is drained.
+		if !errSeen.Load() {
+			// By construction, each map entry has converged to exactly one node.
+			res := make(map[K]V, len(lists))
+			for k, l := range lists {
+				res[k] = l.Front().Value.value
+			}
 
-		// Error path: items can remain in the input, so we wait for the drain
-		if errSeen.Load() {
-			lists = nil // free memory while waiting for the drain
-			<-inputDrained
-			close(out)
-			return
+			out <- Try[map[K]V]{Value: res}
 		}
 
-		// Happy path: the workers exhausted the input, so there is nothing to
-		// drain. By construction, each map entry has converged to exactly one node.
-		res := make(map[K]V, len(lists))
-		for k, l := range lists {
-			res[k] = l.Front().Value.value
-		}
+		lists = nil // help the GC
 
-		out <- Try[map[K]V]{Value: res}
+		// This drain is needed for correctness:
+		// out chan carries settlement signal,
+		// don't close it until the input is drained.
+		Drain(entries)
+
 		close(out)
 	}()
+
+	// This discard is needed for promptness:
+	// it starts earlier than the drain above - when the result is known.
+	// It takes no options: the settlement signal is carried by out, not entries.
+	defer Discard(entries)
 
 	res, _, err := First(out, options...)
 	if err != nil {

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -184,33 +184,37 @@ func TestReduce(t *testing.T) {
 			})
 		})
 
-		th.RunSynctest(t, "settlement", func(t *testing.T) {
-			in := FromChan(th.FromRange(0, 100), nil)
+		th.RunSynctest(t, "context", func(t *testing.T) {
+			ctx, scope := WithContext(t.Context())
+			defer scope.Cancel()
 
-			settled, opt := Settlement()
+			in := FromChan(th.FromRange(0, 100), nil)
 
 			var state int64
 			out, ok, err := Reduce(in, n, func(x, y int) (int, error) {
 				th.SimulateWork(1*time.Second, 2*time.Second)
 				atomic.AddInt64(&state, 1)
 				return x + y, nil
-			}, opt)
+			}, scope)
 
 			th.ExpectNoError(t, err)
 			th.ExpectValue(t, out, 99*100/2)
 			th.ExpectValue(t, ok, true)
-
 			th.ExpectNoRace(state)
 			th.ExpectDrainedChan(t, in)
+			th.ExpectActiveContext(t, ctx)
 
-			<-settled // should not leak
+			scope.Wait()
+
+			th.ExpectCanceledContext(t, ctx)
 		})
 
-		th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+		th.RunSynctest(t, "context (early return)", func(t *testing.T) {
+			ctx, scope := WithContext(t.Context())
+			defer scope.Cancel()
+
 			in := FromChan(th.FromRange(0, 1000), nil)
 			in = th.DelayEach(in, 1)
-
-			settled, opt := Settlement()
 
 			var state int64
 			x, ok, err := Reduce(in, n, func(x, y int) (int, error) {
@@ -219,17 +223,19 @@ func TestReduce(t *testing.T) {
 					return 0, fmt.Errorf("err200")
 				}
 				return x + y, nil
-			}, opt)
+			}, scope)
 
 			th.ExpectError(t, err, "err200")
 			th.ExpectValue(t, x, 0)
 			th.ExpectValue(t, ok, false)
 			th.ExpectOpenChan(t, in)
+			th.ExpectActiveContext(t, ctx)
 
-			<-settled
+			scope.Wait()
 
 			th.ExpectNoRace(state)
 			th.ExpectDrainedChan(t, in)
+			th.ExpectCanceledContext(t, ctx)
 		})
 
 		th.RunSynctest(t, "concurrency", func(t *testing.T) {
@@ -561,10 +567,11 @@ func TestMapReduce(t *testing.T) {
 				})
 			})
 
-			th.RunSynctest(t, "settlement", func(t *testing.T) {
-				in := FromChan(th.FromRange(0, 200), nil)
+			th.RunSynctest(t, "context", func(t *testing.T) {
+				ctx, scope := WithContext(t.Context())
+				defer scope.Cancel()
 
-				settled, opt := Settlement()
+				in := FromChan(th.FromRange(0, 200), nil)
 
 				var stateMapper, stateReducer int64
 				out, err := MapReduce(in,
@@ -578,7 +585,7 @@ func TestMapReduce(t *testing.T) {
 						th.SimulateWork(10*time.Second, 20*time.Second)
 						return x + y, nil
 					},
-					opt,
+					scope,
 				)
 
 				th.ExpectNoError(t, err)
@@ -590,15 +597,19 @@ func TestMapReduce(t *testing.T) {
 				th.ExpectNoRace(stateMapper)
 				th.ExpectNoRace(stateReducer)
 				th.ExpectDrainedChan(t, in)
+				th.ExpectActiveContext(t, ctx)
 
-				<-settled // should not leak
+				scope.Wait()
+
+				th.ExpectCanceledContext(t, ctx)
 			})
 
-			th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+			th.RunSynctest(t, "context (early return)", func(t *testing.T) {
+				ctx, scope := WithContext(t.Context())
+				defer scope.Cancel()
+
 				in := FromChan(th.FromRange(0, 1000), nil)
 				in = th.DelayEach(in, 1)
-
-				settled, opt := Settlement()
 
 				var stateMapper, stateReducer int64
 				out, err := MapReduce(in,
@@ -615,18 +626,20 @@ func TestMapReduce(t *testing.T) {
 						}
 						return x + y, nil
 					},
-					opt,
+					scope,
 				)
 
 				th.ExpectError(t, err, "err200")
 				th.ExpectMap(t, out, nil)
 				th.ExpectOpenChan(t, in)
+				th.ExpectActiveContext(t, ctx)
 
-				<-settled
+				scope.Wait()
 
 				th.ExpectNoRace(stateMapper)
 				th.ExpectNoRace(stateReducer)
 				th.ExpectDrainedChan(t, in)
+				th.ExpectCanceledContext(t, ctx)
 			})
 
 			th.RunSynctest(t, "concurrency", func(t *testing.T) {

--- a/reduce_test.go
+++ b/reduce_test.go
@@ -185,7 +185,7 @@ func TestReduce(t *testing.T) {
 		})
 
 		th.RunSynctest(t, "context", func(t *testing.T) {
-			ctx, scope := WithContext(t.Context())
+			scope, ctx := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 100), nil)
@@ -210,7 +210,7 @@ func TestReduce(t *testing.T) {
 		})
 
 		th.RunSynctest(t, "context (early return)", func(t *testing.T) {
-			ctx, scope := WithContext(t.Context())
+			scope, ctx := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 1000), nil)
@@ -568,7 +568,7 @@ func TestMapReduce(t *testing.T) {
 			})
 
 			th.RunSynctest(t, "context", func(t *testing.T) {
-				ctx, scope := WithContext(t.Context())
+				scope, ctx := NewScope(t.Context())
 				defer scope.Cancel()
 
 				in := FromChan(th.FromRange(0, 200), nil)
@@ -605,7 +605,7 @@ func TestMapReduce(t *testing.T) {
 			})
 
 			th.RunSynctest(t, "context (early return)", func(t *testing.T) {
-				ctx, scope := WithContext(t.Context())
+				scope, ctx := NewScope(t.Context())
 				defer scope.Cancel()
 
 				in := FromChan(th.FromRange(0, 1000), nil)

--- a/scope.go
+++ b/scope.go
@@ -1,0 +1,93 @@
+package rill
+
+import (
+	"context"
+	"sync"
+)
+
+// A Scope tracks the lifecycle of a pipeline and lets the caller wait until
+// all of its work is done - including any work that happens after a sink's
+// early return.
+//
+// A scope passed to a sink as a [SinkOption] tracks not only that sink, but
+// also the whole pipeline behind it.
+//
+// For branching pipelines (see [Tee]), multiple sinks can be attached to the
+// same scope.
+type Scope interface {
+	SinkOption
+
+	// Cancel cancels the scope's Context. It does not wait for the work
+	// to finish.
+	Cancel()
+
+	// Wait is called after the sink has returned. It cancels the scope's
+	// Context and blocks until the pipeline has settled: every user callback
+	// has returned and any other remaining work is finished.
+	//
+	// Wait can be called any number of times and from multiple goroutines,
+	// but only after every sink attached to the scope has returned.
+	// Attaching a new sink to the scope after Wait has been called panics.
+	Wait()
+}
+
+type scope struct {
+	cancelFunc context.CancelFunc
+
+	mu         sync.Mutex
+	cond       sync.Cond
+	cnt        int
+	waitCalled bool
+}
+
+func (s *scope) apply(options *sinkOptions) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Any join after Wait was called means Wait was called too early: the sink
+	// had not returned yet, so Wait could not have covered it.
+	if s.waitCalled {
+		panic("rill: Wait must be called after all sinks attached to the scope have returned")
+	}
+
+	s.cnt++
+	options.settleFuncs = append(options.settleFuncs, s.release)
+}
+
+func (s *scope) release() {
+	s.mu.Lock()
+	s.cnt--
+	s.mu.Unlock()
+
+	s.cond.Broadcast()
+}
+
+func (s *scope) Cancel() {
+	s.cancelFunc()
+}
+
+func (s *scope) Wait() {
+	s.cancelFunc()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.waitCalled = true
+	for s.cnt > 0 {
+		s.cond.Wait()
+	}
+}
+
+// WithContext creates a new [Scope] and an associated Context derived from ctx.
+//
+// The Context is canceled by [Scope.Cancel] or [Scope.Wait]. At least one
+// of them must be called, typically via defer, to prevent the Context from
+// leaking.
+func WithContext(ctx context.Context) (context.Context, Scope) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	s := &scope{cancelFunc: cancel}
+	s.cond.L = &s.mu
+
+	return ctx, s
+}

--- a/scope.go
+++ b/scope.go
@@ -57,7 +57,12 @@ func (s *scope) apply(options *sinkOptions) {
 func (s *scope) release() {
 	s.mu.Lock()
 	s.cnt--
+	negative := s.cnt < 0
 	s.mu.Unlock()
+
+	if negative {
+		panic("rill: internal error: negative scope counter")
+	}
 
 	s.cond.Broadcast()
 }

--- a/scope.go
+++ b/scope.go
@@ -27,7 +27,7 @@ type Scope interface {
 	//
 	// Wait can be called any number of times and from multiple goroutines,
 	// but only after every sink attached to the scope has returned.
-	// Attaching a new sink to the scope after Wait has been called panics.
+	// Once Wait has been called, attaching a new sink to the scope panics.
 	Wait()
 }
 

--- a/scope.go
+++ b/scope.go
@@ -83,16 +83,16 @@ func (s *scope) Wait() {
 	}
 }
 
-// WithContext creates a new [Scope] and an associated Context derived from ctx.
+// NewScope creates a new [Scope] and an associated Context derived from ctx.
 //
 // The Context is canceled by [Scope.Cancel] or [Scope.Wait]. At least one
 // of them must be called, typically via defer, to prevent the Context from
 // leaking.
-func WithContext(ctx context.Context) (context.Context, Scope) {
+func NewScope(ctx context.Context) (Scope, context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	s := &scope{cancelFunc: cancel}
 	s.cond.L = &s.mu
 
-	return ctx, s
+	return s, ctx
 }

--- a/scope.go
+++ b/scope.go
@@ -21,9 +21,9 @@ type Scope interface {
 	// to finish.
 	Cancel()
 
-	// Wait is called after the sink has returned. It cancels the scope's
-	// Context and blocks until the pipeline has settled: every user callback
-	// has returned and any other remaining work is finished.
+	// Wait cancels the scope's Context and blocks until the pipeline has
+	// settled: every user callback has returned and any other remaining
+	// work is finished.
 	//
 	// Wait can be called any number of times and from multiple goroutines,
 	// but only after every sink attached to the scope has returned.

--- a/scope_test.go
+++ b/scope_test.go
@@ -1,0 +1,163 @@
+package rill
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/destel/rill/internal/th"
+)
+
+func TestScope(t *testing.T) {
+	th.RunSynctest(t, "one branch discarded", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
+		var state int64
+
+		in := FromChan(th.FromRange(0, 100), nil)
+		in = th.DelayEach(in, 1)
+
+		in1, in2 := Tee(in)
+
+		out1 := Map(in1, 5, func(x int) (int, error) {
+			atomic.AddInt64(&state, 1)
+			th.SimulateWork(1*time.Second, 2*time.Second)
+			return x * 2, nil
+		})
+
+		Discard(out1, scope)
+
+		out2 := OrderedFilter(in2, 5, func(x int) (bool, error) {
+			atomic.AddInt64(&state, 1)
+			th.SimulateWork(1*time.Second, 2*time.Second)
+			return x >= 50, nil
+		})
+
+		res, ok, err := First(out2, scope)
+
+		th.ExpectNoError(t, err)
+		th.ExpectValue(t, ok, true)
+		th.ExpectValue(t, res, 50)
+		th.ExpectActiveContext(t, ctx)
+
+		scope.Wait()
+
+		th.ExpectNoRace(state)
+		th.ExpectCanceledContext(t, ctx)
+	})
+
+	th.RunSynctest(t, "two sinks", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
+		var state int64
+
+		in := FromChan(th.FromRange(0, 100), nil)
+		in = th.DelayEach(in, 1)
+
+		in1, in2 := Tee(in)
+
+		out1 := OrderedFilter(in1, 5, func(x int) (bool, error) {
+			atomic.AddInt64(&state, 1)
+			th.SimulateWork(1*time.Second, 2*time.Second)
+			return x >= 50, nil
+		})
+
+		// this branch is slower
+		out2 := OrderedFilter(in2, 5, func(x int) (bool, error) {
+			atomic.AddInt64(&state, 1)
+			th.SimulateWork(100*time.Second, 200*time.Second)
+			return x >= 15, nil
+		})
+
+		var res1, res2 int
+		var ok1, ok2 bool
+		var err1, err2 error
+
+		var sinksReturned sync.WaitGroup
+		sinksReturned.Go(func() { res1, ok1, err1 = First(out1, scope) })
+		sinksReturned.Go(func() { res2, ok2, err2 = First(out2, scope) })
+		sinksReturned.Wait()
+
+		th.ExpectNoError(t, err1)
+		th.ExpectValue(t, ok1, true)
+		th.ExpectValue(t, res1, 50)
+		th.ExpectNoError(t, err2)
+		th.ExpectValue(t, ok2, true)
+		th.ExpectValue(t, res2, 15)
+		th.ExpectActiveContext(t, ctx)
+
+		scope.Wait()
+
+		th.ExpectNoRace(state)
+		th.ExpectCanceledContext(t, ctx)
+	})
+
+	t.Run("wait called before sinks return", func(t *testing.T) {
+		th.ExpectLeak(t, func(t *testing.T) {
+			var panicsCount atomic.Int64
+			catchSinkPanic := func() {
+				if recover() != nil {
+					panicsCount.Add(1)
+				}
+			}
+
+			_, scope := WithContext(t.Context())
+			defer scope.Cancel()
+
+			in := FromChan(th.FromRange(0, 100), nil)
+			in = th.DelayEach(in, 1*time.Second)
+
+			in1, in2 := Tee(in)
+
+			go func() {
+				defer catchSinkPanic()
+				_, _, _ = First(in1, scope)
+			}()
+			go func() {
+				defer catchSinkPanic()
+				_, _, _ = First(in2, scope)
+			}()
+
+			// Calling wait w/o waiting for sinks to return
+			// Each sink taks 1s of fake time, so this is deterministic
+			scope.Wait()
+
+			// Eventually both goroutines return
+			time.Sleep(24 * time.Hour)
+
+			th.ExpectValue(t, panicsCount.Load(), 2)
+		})
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		scope.Cancel()
+
+		th.ExpectCanceledContext(t, ctx)
+	})
+
+	th.RunSynctest(t, "multiple waiters", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
+		in := FromChan(th.FromRange(0, 100), nil)
+		in = th.DelayEach(in, 1*time.Second)
+		Discard(in, scope)
+
+		var returnedCnt atomic.Int64
+		for range 10 {
+			go func() {
+				scope.Wait()
+				returnedCnt.Add(1)
+			}()
+		}
+
+		time.Sleep(24 * time.Hour)
+
+		th.ExpectValue(t, returnedCnt.Load(), 10)
+		th.ExpectCanceledContext(t, ctx)
+	})
+}

--- a/scope_test.go
+++ b/scope_test.go
@@ -132,6 +132,23 @@ func TestScope(t *testing.T) {
 		})
 	})
 
+	t.Run("more settles than attaches", func(t *testing.T) {
+		_, s := WithContext(t.Context())
+
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected panic")
+			}
+		}()
+
+		impl, ok := s.(*scope)
+		if !ok {
+			t.Fatal("unexpected Scope implementation")
+		}
+
+		impl.release()
+	})
+
 	t.Run("cancel", func(t *testing.T) {
 		ctx, scope := WithContext(t.Context())
 		scope.Cancel()

--- a/scope_test.go
+++ b/scope_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestScope(t *testing.T) {
 	th.RunSynctest(t, "one branch discarded", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		var state int64
@@ -49,7 +49,7 @@ func TestScope(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "two sinks", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		var state int64
@@ -104,7 +104,7 @@ func TestScope(t *testing.T) {
 				}
 			}
 
-			_, scope := WithContext(t.Context())
+			scope, _ := NewScope(t.Context())
 			defer scope.Cancel()
 
 			in := FromChan(th.FromRange(0, 100), nil)
@@ -133,7 +133,7 @@ func TestScope(t *testing.T) {
 	})
 
 	t.Run("more settles than attaches", func(t *testing.T) {
-		_, s := WithContext(t.Context())
+		s, _ := NewScope(t.Context())
 
 		defer func() {
 			if recover() == nil {
@@ -150,14 +150,14 @@ func TestScope(t *testing.T) {
 	})
 
 	t.Run("cancel", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		scope.Cancel()
 
 		th.ExpectCanceledContext(t, ctx)
 	})
 
 	th.RunSynctest(t, "multiple waiters", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromChan(th.FromRange(0, 100), nil)

--- a/util_test.go
+++ b/util_test.go
@@ -22,11 +22,13 @@ func TestDiscard(t *testing.T) {
 		Discard[int](nil)
 	})
 
-	t.Run("nil w settlement", func(t *testing.T) {
+	t.Run("nil w context", func(t *testing.T) {
 		th.ExpectBlock(t, func(t *testing.T) {
-			settled, opt := Settlement()
-			Discard[int](nil, opt)
-			<-settled
+			_, scope := WithContext(t.Context())
+			defer scope.Cancel()
+
+			Discard[int](nil, scope)
+			scope.Wait()
 		})
 	})
 
@@ -42,31 +44,48 @@ func TestDiscard(t *testing.T) {
 		th.ExpectDrainedChan(t, in)
 	})
 
-	th.RunSynctest(t, "normal w settlement", func(t *testing.T) {
+	th.RunSynctest(t, "normal w context", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := th.FromRange(0, 100)
 		in = th.DelayEach(in, 1*time.Second)
 
-		settled, opt := Settlement()
-		Discard(in, opt) // doesn't block
+		Discard(in, scope) // doesn't block
 
 		time.Sleep(60 * time.Second)
-		th.ExpectOpenChan(t, in)
 
-		<-settled
+		th.ExpectOpenChan(t, in)
+		th.ExpectActiveContext(t, ctx)
+
+		scope.Wait()
+
 		th.ExpectDrainedChan(t, in)
+		th.ExpectCanceledContext(t, ctx)
 	})
 
-	th.RunSynctest(t, "two settlements", func(t *testing.T) {
+	th.RunSynctest(t, "two scopes", func(t *testing.T) {
 		in := th.FromRange(0, 100)
 		in = th.DelayEach(in, 1*time.Second)
 
-		settled1, opt1 := Settlement()
-		settled2, opt2 := Settlement()
-		Discard(in, opt1, opt2) // doesn't block
+		ctx1, scope1 := WithContext(t.Context())
+		defer scope1.Cancel()
+		ctx2, scope2 := WithContext(t.Context())
+		defer scope2.Cancel()
 
-		<-settled1
+		Discard(in, scope1, scope2) // doesn't block
+
+		th.ExpectActiveContext(t, ctx1)
+		th.ExpectActiveContext(t, ctx2)
+
+		scope1.Wait()
+
 		th.ExpectDrainedChan(t, in)
-		<-settled2
+		th.ExpectCanceledContext(t, ctx1)
+		th.ExpectActiveContext(t, ctx2)
+
+		scope2.Wait()
+		th.ExpectCanceledContext(t, ctx2)
 	})
 
 	th.RunSynctest(t, "closed", func(t *testing.T) {
@@ -76,16 +95,21 @@ func TestDiscard(t *testing.T) {
 		th.ExpectDrainedChan(t, in)
 	})
 
-	th.RunSynctest(t, "closed w settlement", func(t *testing.T) {
+	th.RunSynctest(t, "closed w context", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := make(chan int)
 		close(in)
 
-		settled, opt := Settlement()
-		Discard(in, opt)
+		Discard(in, scope)
 
 		th.ExpectDrainedChan(t, in)
+		th.ExpectActiveContext(t, ctx)
 
-		<-settled // should not leak
+		scope.Wait() // should not leak
+
+		th.ExpectCanceledContext(t, ctx)
 	})
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -24,7 +24,7 @@ func TestDiscard(t *testing.T) {
 
 	t.Run("nil w context", func(t *testing.T) {
 		th.ExpectBlock(t, func(t *testing.T) {
-			_, scope := WithContext(t.Context())
+			scope, _ := NewScope(t.Context())
 			defer scope.Cancel()
 
 			Discard[int](nil, scope)
@@ -45,7 +45,7 @@ func TestDiscard(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "normal w context", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := th.FromRange(0, 100)
@@ -68,9 +68,9 @@ func TestDiscard(t *testing.T) {
 		in := th.FromRange(0, 100)
 		in = th.DelayEach(in, 1*time.Second)
 
-		ctx1, scope1 := WithContext(t.Context())
+		scope1, ctx1 := NewScope(t.Context())
 		defer scope1.Cancel()
-		ctx2, scope2 := WithContext(t.Context())
+		scope2, ctx2 := NewScope(t.Context())
 		defer scope2.Cancel()
 
 		Discard(in, scope1, scope2) // doesn't block
@@ -96,7 +96,7 @@ func TestDiscard(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "closed w context", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := make(chan int)

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -111,7 +111,7 @@ func TestToSlice(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "context", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)
@@ -129,7 +129,7 @@ func TestToSlice(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "context (early return)", func(t *testing.T) {
-		ctx, scope := WithContext(t.Context())
+		scope, ctx := NewScope(t.Context())
 		defer scope.Cancel()
 
 		in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -110,35 +110,44 @@ func TestToSlice(t *testing.T) {
 		})
 	})
 
-	th.RunSynctest(t, "settlement", func(t *testing.T) {
+	th.RunSynctest(t, "context", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)
 
-		settled, opt := Settlement()
-		outSlice, err := ToSlice(in, opt)
+		outSlice, err := ToSlice(in, scope)
 
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
 		th.ExpectNoError(t, err)
 		th.ExpectDrainedChan(t, in)
+		th.ExpectActiveContext(t, ctx)
 
-		<-settled // should not leak
+		scope.Wait()
+
+		th.ExpectCanceledContext(t, ctx)
 	})
 
-	th.RunSynctest(t, "settlement (early return)", func(t *testing.T) {
+	th.RunSynctest(t, "context (early return)", func(t *testing.T) {
+		ctx, scope := WithContext(t.Context())
+		defer scope.Cancel()
+
 		in := FromSlice([]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, nil)
 		in = replaceWithError(in, 5, fmt.Errorf("err005"))
 		in = replaceWithError(in, 7, fmt.Errorf("err007"))
 		in = th.DelayEach(in, 1)
 
-		settled, opt := Settlement()
-		outSlice, err := ToSlice(in, opt)
+		outSlice, err := ToSlice(in, scope)
 
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 3, 4})
 		th.ExpectError(t, err, "err005")
 		th.ExpectOpenChan(t, in)
+		th.ExpectActiveContext(t, ctx)
 
-		<-settled
+		scope.Wait()
 
 		th.ExpectDrainedChan(t, in)
+		th.ExpectCanceledContext(t, ctx)
 	})
 }
 


### PR DESCRIPTION
> This feature was replaced by WithContext (#113)

Blocking sinks in rill return as soon as their outcome is known, which can happen before the entire input is
consumed and processed. That's deliberate – the sooner we get control back, the sooner we can cancel the context
to prevent the current and future work.

Such a model gives promptness, but does not expose an "everything is done" event (also called
settlement), so any work happening after the early return stays unobservable. That event might be
necessary to free a shared resource, or to safely observe side effects the callbacks produced. Simply
put, users sometimes need `sync.WaitGroup.Wait()`, but for pipelines.

This PR adds a Scope API that combines both the first class Context integration
and a `Wait` method that blocks until the pipeline settles.

```go
scope, ctx := rill.NewScope(ctx)
defer scope.Cancel()

// other pipeline stages go here

err := rill.ForEach(stream, 5, func(x int) error {
	return process(ctx, x)
}, scope)
scope.Wait()
```

A scope exposes two methods, `Wait` and `Cancel`. Both cancel the associated context, but `Wait` also
blocks until the pipeline is settled. At least one of them must be called to ensure the underlying
context does not leak.

Settlement is opt-in. `Wait` goes wherever the code first needs the pipeline fully stopped: right after the sink, after the error handling, or in a defer, so the function returns settled. If `Wait` is omitted, a scope with a deferred Cancel behaves like a normal cancellable context, which is still useful for stopping the remaining context-aware work.

## How it works

We say a pipeline stage is settled once it won't do any more work: it has fully consumed its input, and
every callback it started has returned.

Most stages already expose this, they just don't call it that. `Map`, `Filter`, `FromSlice` and friends
close their output channel only after they've settled, so a closed output *is* the settlement signal. And
it composes backwards: a settled stage means the stage before it closed its output, and so on up to the
source. Sinks were the hole – no output channel, nothing to close, no signal.

A scope's `Wait` blocks until every sink attached to it settles. By the inductive argument above, that means
that all upstream stages, and hence the entire pipeline, have also settled.

## Compared with errgroup

Most Go developers know errgroup, and the scope API was designed to be similar, while staying
pipeline friendly. The table below shows both similarities and differences.

|                                  | errgroup                    | rill                                    |
|----------------------------------|-----------------------------|-----------------------------------------|
| creates a cancellable context    | yes                         | yes                          |
| on cancellation, stops work already in flight | no – callbacks must watch the context | no – callbacks must watch the context |
| on cancellation, prevents new work from starting | no – the code must watch the context and stop calling `g.Go`  | no – the source must watch the context and stop producing |
| nothing runs after `Wait`        | yes                         | yes                                     |
| how the error is delivered | via `Wait` | via the sink, before `Wait` |
| when `Wait` can be called | almost anytime | after the sink has returned |
| when `Wait` cancels the context  | when it returns      | before it blocks (sink outcome already known) |
| who cancels the context after an error | the group itself | typically the `Wait` that follows the sink call, or a deferred `Cancel` |

## Compatibility

Existing call sites keep working, since the options are variadic. But every sink's signature changed, so
code that assigns a sink to an exact function type has to be updated. Technically, this is a breaking
API change.






