### PR TITLE
Generalize Tee to any channel

### DIFF
--- a/internal/th/helpers.go
+++ b/internal/th/helpers.go
@@ -3,7 +3,6 @@ package th
 import (
 	"fmt"
 	"math/rand"
-	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -102,18 +101,6 @@ func DelayEach[A any](in <-chan A, delay time.Duration) <-chan A {
 func SimulateWork(min, max time.Duration) {
 	d := min + time.Duration(rand.Int63n(int64(max-min+1)))
 	time.Sleep(d)
-}
-
-func DoConcurrently(ff ...func()) {
-	var wg sync.WaitGroup
-
-	for _, f := range ff {
-		wg.Go(func() {
-			f()
-		})
-	}
-
-	wg.Wait()
 }
 
 func TestBothOrderings(t *testing.T, f func(t *testing.T, ord bool)) {

--- a/merge.go
+++ b/merge.go
@@ -104,25 +104,26 @@ func OrderedSplit2[A any](in <-chan Try[A], n int, f func(A) (bool, error)) (out
 	return
 }
 
-// Tee returns two streams that are identical to the input stream (both errors and values).
-// Both output streams must be consumed independently to avoid deadlocks.
+// Tee duplicates the input: it returns two channels that both carry every
+// item from the input, forwarded as it arrives. Both outputs are closed
+// once the input is exhausted.
 //
-// This is a non-blocking function that processes items in a single goroutine.
-// See the package documentation for more information on non-blocking functions and error handling.
+// The outputs must be consumed concurrently to avoid a deadlock.
 //
-// If deep copying of values is needed, use [Map] on one or both outputs:
+// If deep copying of values is needed, use [Map] on one or both
+// outputs:
 //
 //	out1, out2 := rill.Tee(in)
 //	out2 = rill.Map(out2, 1, func(x A) (A, error) {
 //		return deepCopy(x), nil
 //	})
-func Tee[A any](in <-chan Try[A]) (<-chan Try[A], <-chan Try[A]) {
+func Tee[A any](in <-chan A) (<-chan A, <-chan A) {
 	if in == nil {
 		return nil, nil
 	}
 
-	out1 := make(chan Try[A])
-	out2 := make(chan Try[A])
+	out1 := make(chan A)
+	out2 := make(chan A)
 
 	go func() {
 		defer close(out1)

--- a/merge_test.go
+++ b/merge_test.go
@@ -2,6 +2,7 @@ package rill
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -48,10 +49,10 @@ func TestSplit2(t *testing.T) {
 				})
 
 				var outSliceTrue, outSliceFalse []Item[int]
-				th.DoConcurrently(
-					func() { outSliceTrue = toItemSlice(outTrue) },
-					func() { outSliceFalse = toItemSlice(outFalse) },
-				)
+				var wg sync.WaitGroup
+				wg.Go(func() { outSliceTrue = toItemSlice(outTrue) })
+				wg.Go(func() { outSliceFalse = toItemSlice(outFalse) })
+				wg.Wait()
 
 				var expectedTrue, expectedFalse []Item[int]
 				for i := range 20 {
@@ -105,11 +106,10 @@ func TestSplit2(t *testing.T) {
 				})
 
 				var outSliceTrue, outSliceFalse []string
-
-				th.DoConcurrently(
-					func() { outSliceTrue = toUnifiedStringSlice(outTrue, "%03d") },
-					func() { outSliceFalse = toUnifiedStringSlice(outFalse, "%03d") },
-				)
+				var wg sync.WaitGroup
+				wg.Go(func() { outSliceTrue = toUnifiedStringSlice(outTrue, "%03d") })
+				wg.Go(func() { outSliceFalse = toUnifiedStringSlice(outFalse, "%03d") })
+				wg.Wait()
 
 				if ord || n == 1 {
 					th.ExpectSorted(t, outSliceTrue)
@@ -136,11 +136,10 @@ func TestTee(t *testing.T) {
 		out1, out2 := Tee(in)
 
 		var outSlice1, outSlice2 []int
-
-		th.DoConcurrently(
-			func() { outSlice1 = th.ToSlice(out1) },
-			func() { outSlice2 = th.ToSlice(out2) },
-		)
+		var wg sync.WaitGroup
+		wg.Go(func() { outSlice1 = th.ToSlice(out1) })
+		wg.Go(func() { outSlice2 = th.ToSlice(out2) })
+		wg.Wait()
 
 		expected := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -132,26 +132,17 @@ func TestTee(t *testing.T) {
 	})
 
 	th.RunSynctest(t, "correctness", func(t *testing.T) {
-		// Create input with mixed values and errors
-		in := FromChan(th.FromRange(0, 10), nil)
-		in = replaceWithError(in, 2, fmt.Errorf("err2"))
-		in = replaceWithError(in, 7, fmt.Errorf("err7"))
-
+		in := th.FromRange(0, 10)
 		out1, out2 := Tee(in)
 
-		var outSlice1, outSlice2 []Item[int]
+		var outSlice1, outSlice2 []int
 
 		th.DoConcurrently(
-			func() { outSlice1 = toItemSlice(out1) },
-			func() { outSlice2 = toItemSlice(out2) },
+			func() { outSlice1 = th.ToSlice(out1) },
+			func() { outSlice2 = th.ToSlice(out2) },
 		)
 
-		var expected []Item[int]
-		expected = appendVal(expected, 0, 1)
-		expected = appendErr(expected, fmt.Errorf("err2"))
-		expected = appendVal(expected, 3, 4, 5, 6)
-		expected = appendErr(expected, fmt.Errorf("err7"))
-		expected = appendVal(expected, 8, 9)
+		expected := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
 		// Both outputs should be identical
 		th.ExpectSlice(t, outSlice1, expected)
@@ -160,13 +151,13 @@ func TestTee(t *testing.T) {
 
 	t.Run("non concurrent reads", func(t *testing.T) {
 		th.ExpectBlock(t, func(t *testing.T) {
-			in := FromChan(th.FromRange(0, 10), nil)
+			in := th.FromRange(0, 10)
 			out1, out2 := Tee(in)
 
 			// Reading out1 blocks forever: the producer gets stuck sending to the unread out2,
 			// so it stops feeding out1 too. The second call is never reached.
-			toItemSlice(out1)
-			toItemSlice(out2)
+			th.ToSlice(out1)
+			th.ToSlice(out2)
 		})
 	})
 }

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -2,6 +2,7 @@ package rill
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -283,16 +284,17 @@ func TestToChans(t *testing.T) {
 
 		var outSlice []int
 		var errSlice []string
-		th.DoConcurrently(
-			func() { outSlice = th.ToSlice(out) },
-			func() {
-				for err := range errs {
-					if err != nil {
-						errSlice = append(errSlice, err.Error())
-					}
+
+		var wg sync.WaitGroup
+		wg.Go(func() { outSlice = th.ToSlice(out) })
+		wg.Go(func() {
+			for err := range errs {
+				if err != nil {
+					errSlice = append(errSlice, err.Error())
 				}
-			},
-		)
+			}
+		})
+		wg.Wait()
 
 		th.ExpectSlice(t, outSlice, []int{0, 1, 2, 4, 5, 6, 8, 9})
 		th.ExpectSlice(t, errSlice, []string{"err003", "err007"})


### PR DESCRIPTION
Tee now accepts any channel, not only streams of `Try`. It never looked at the items it forwarded, so the Try constraint was incidental, and plain channels can now be duplicated the same way streams are.

Existing inferred call sites like `Tee(stream)` are backwards compatible and keep working. 
Explicit instantiations such as `rill.Tee[User](stream)` must become `rill.Tee[rill.Try[User]](stream)`.